### PR TITLE
perf: Improve animation performance and reduce frame drops

### DIFF
--- a/include/sway/desktop/animation.h
+++ b/include/sway/desktop/animation.h
@@ -112,6 +112,11 @@ void animation_end();
 // Animates one frame for output
 void animation_animate(struct wlr_output *output);
 
+// Returns the output currently being animated, or NULL if not in a
+// per-output animation call. Used by callbacks to scope work to a
+// single output instead of processing all outputs.
+struct wlr_output *animation_get_current_output(void);
+
 // Is an animation enabled?
 bool animation_enabled();
 

--- a/sway/desktop/animation.c
+++ b/sway/desktop/animation.c
@@ -141,6 +141,10 @@ struct sway_animation {
 	uint32_t id;
 
 	list_t *outputs;
+	// The output currently being rendered. When set, animation callbacks
+	// should only process this output instead of looping all outputs.
+	// NULL when called from a non-per-output path (e.g. disabled animations).
+	struct wlr_output *current_output;
 	enum sway_animation_enabled enabled;
 	struct {
 		struct sway_animation_path *path;
@@ -495,6 +499,10 @@ bool animation_enabled() {
 	}
 }
 
+struct wlr_output *animation_get_current_output(void) {
+	return animation ? animation->current_output : NULL;
+}
+
 bool animation_animating(struct wlr_output *output) {
 	if (animation->enabled == ANIMATION_ENABLED_NO) {
 		return false;
@@ -644,7 +652,11 @@ void animation_animate(struct wlr_output *output) {
 	root->filters.output_filter = animation_output_filter;
 	root->filters.output_filter_data = NULL;
 
+	// Set current output so callback_step only processes this output
+	// instead of looping all animating outputs (avoids N² work)
+	animation->current_output = output;
 	animation->current.callbacks.callback_step(animation->current.callbacks.callback_step_data);
+	animation->current_output = NULL;
 
 	// Restore old filters
 	root->filters.output_filter = old_filter;

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -20,6 +20,7 @@
 #include <wlr/util/transform.h>
 #include "log.h"
 #include "sway/config.h"
+#include "sway/desktop/animation.h"
 #include "sway/desktop/transaction.h"
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"
@@ -322,6 +323,13 @@ static int output_repaint_timer_handler(void *data) {
 
 	if (!wlr_output_commit_state(output->wlr_output, &pending)) {
 		sway_log(SWAY_ERROR, "Page-flip failed on output %s", output->wlr_output->name);
+	} else if (animation_animating(output->wlr_output)) {
+		// During animation, schedule the next frame directly from the
+		// vblank-driven render path instead of relying solely on the
+		// independent 16ms animation timer. This keeps animation frames
+		// synchronized with the display's actual refresh rate and avoids
+		// timer/vblank phase drift that causes periodic micro-freezes.
+		wlr_output_schedule_frame(output->wlr_output);
 	}
 	wlr_output_state_finish(&pending);
 	return 0;

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -1455,13 +1455,25 @@ static void animate_root(struct sway_root *root) {
 	if (fs) {
 		animate_fullscreen(root->layers.fullscreen_global, fs, NULL);
 	} else {
-		for (int i = 0; i < root->outputs->length; i++) {
-			struct sway_output *output = root->outputs->items[i];
-			if (!output->enabled || !output->wlr_output->enabled ||
-				!root->filters.output_filter(output, root->filters.output_filter_data)) {
-				continue;
+		// When called from a per-output render path, only animate the
+		// output currently being rendered. This avoids O(N²) work where
+		// each output's render re-animates all other outputs.
+		struct wlr_output *cur = animation_get_current_output();
+		if (cur && cur->data) {
+			struct sway_output *output = cur->data;
+			if (output->enabled && output->wlr_output->enabled &&
+				root->filters.output_filter(output, root->filters.output_filter_data)) {
+				animate_output(output);
 			}
-			animate_output(output);
+		} else {
+			for (int i = 0; i < root->outputs->length; i++) {
+				struct sway_output *output = root->outputs->items[i];
+				if (!output->enabled || !output->wlr_output->enabled ||
+					!root->filters.output_filter(output, root->filters.output_filter_data)) {
+					continue;
+				}
+				animate_output(output);
+			}
 		}
 	}
 	arrange_popups(root->layers.popup);


### PR DESCRIPTION
1/ Fix O(N²) animation work on multi-monitor setups by scoping animate_root to only process the output currently being rendered, instead of re-animating all outputs from each output's render path.

2/ Reduce per-frame scene tree walk overhead by having output_configure_scene walk only the current output's layer subtrees and global trees, instead of the entire scene graph including all other outputs' nodes.

3/ Sync animation frame scheduling to display vblank by requesting the next frame directly after a successful commit during animation, rather than relying solely on the independent 16ms timer whose phase drifts relative to the display refresh rate, causing periodic frame drops.

Fix 3 in output_repaint_timer_handler() was the one that really made the difference for me.  But I figured the other 2 were still worth including in that PR.
