### PR TITLE
layout: reap empty parent after moving container

### DIFF
--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -925,7 +925,6 @@ void layout_move_container_to_workspace(struct sway_container *container, struct
 		container_detach_update_parent_fullscreen_layout(parent, container);
 		container_update_representation(parent);
 		node_set_dirty(&parent->node);
-		container_reap_empty(parent);
 		layout_add_view(workspace, active, container);
 		node_set_dirty(&container->node);
 	}
@@ -1454,8 +1453,6 @@ static bool layout_move_container_nomode(struct sway_container *container, enum 
 			struct sway_container *active = new_parent->current.focused_inactive_child;
 			int new_index = layout_insert_compute_index(new_parent->pending.children, active, pos);
 			layout_insert_into_container(new_parent, container, new_index);
-			// Delete old parent container
-			container_reap_empty(parent);
 		}
 		apply_container_sizes(new_parent, layout_toggle_size_width_fraction(workspace),
 			layout_toggle_size_height_fraction(workspace), OPERATION_FOCUS);


### PR DESCRIPTION
This commit fixes a bug in layout move commands (`layout_move_container_nomode` and `layout_move_container_to_workspace`) where they were calling `container_reap_empty` on the parent container.

We removed the redundant `container_reap_empty` calls to avoid unnecessary operations.

Reproduction instructions:
1. Start scroll.
2. Open two windows (they will be tiled vertically by default).
3. Focus the second window.
4. Run the command: `move left nomode`.