### PR TITLE
Clean up spaces at exit to avoid LSan warnings

### DIFF
--- a/include/sway/tree/space.h
+++ b/include/sway/tree/space.h
@@ -48,4 +48,7 @@ void space_load(struct sway_workspace *workspace, const char *name, enum sway_sp
 // Delete a space if it exists
 void space_delete(const char *name);
 
+// Delete all spaces
+void space_destroy_all(void);
+
 #endif // _SWAY_SPACE_H

--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -14,6 +14,7 @@
 #include "sway/tree/container.h"
 #include "sway/tree/root.h"
 #include "sway/tree/workspace.h"
+#include "sway/tree/space.h"
 #include "list.h"
 #include "log.h"
 #include "util.h"
@@ -90,6 +91,7 @@ struct sway_root *root_create(struct wl_display *wl_display) {
 }
 
 void root_destroy(struct sway_root *root) {
+	space_destroy_all();
 	list_free(root->spaces);
 	list_free(root->scratchpad);
 	list_free(root->non_desktop_outputs);

--- a/sway/tree/space.c
+++ b/sway/tree/space.c
@@ -406,3 +406,10 @@ void space_delete(const char *name) {
 		space_destroy(space);
 	}
 }
+
+void space_destroy_all(void) {
+	while (root->spaces->length > 0) {
+		struct sway_space *space = root->spaces->items[root->spaces->length - 1];
+		space_destroy(space);
+	}
+}


### PR DESCRIPTION
We now cleanly destroy all spaces on shutdown to avoid LeakSanitizer warnings for active 'sway_space' structs and the 'root->spaces' list.

- Implemented 'space_destroy_all()' to free all spaces in reverse order.
- Called 'space_destroy_all()' in 'root_destroy()'.

Reproduction:
1. Run scroll.
2. Create one or more spaces (e.g. using scroll command 'space save <name>').
3. Exit scroll.
4. LSan will report memory leaks of 'struct sway_space' objects and the 'root->spaces' list.