### PR TITLE
Fix use-after-free in workspace split destroy

### DIFF
--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -325,6 +325,15 @@ void workspace_destroy(struct sway_workspace *workspace) {
 void workspace_begin_destroy(struct sway_workspace *workspace) {
 	sway_log(SWAY_DEBUG, "Destroying workspace '%s'", workspace->name);
 	ipc_event_workspace(NULL, workspace, "empty"); // intentional
+	if (workspace->split.split != WORKSPACE_SPLIT_NONE) {
+		struct sway_workspace *sibling = workspace->split.sibling;
+		sibling->split.split = WORKSPACE_SPLIT_NONE;
+		sibling->layers.tiling->node.info.output_box = NULL;
+		sibling->split.sibling = NULL;
+		node_set_dirty(&sibling->node);
+		arrange_workspace(sibling);
+	}
+
 	wl_signal_emit_mutable(&workspace->node.events.destroy, &workspace->node);
 
 	wlr_ext_workspace_handle_v1_destroy(workspace->ext_workspace);


### PR DESCRIPTION
When a split workspace is destroyed, its sibling workspace's split state was not being properly cleaned up. Specifically, the sibling's split.split remained set to WORKSPACE_SPLIT_HORIZONTAL or WORKSPACE_SPLIT_VERTICAL, and it still pointed to the destroyed workspace as its sibling.

This led to use-after-free when the sibling workspace was later accessed or rearranged, as it tried to access the destroyed sibling workspace.

We fix this by resetting the sibling's split state to WORKSPACE_SPLIT_NONE, clearing the sibling pointer, clearing the output box, marking the sibling node as dirty, and arranging the sibling workspace so it can claim the full output area.

Reproduction:
1. Open Window 1 on Workspace 1 (active on output HEADLESS-1).
2. Split Workspace 1, creating Workspace 2 as its sibling. Workspace 1 has Window 1, Workspace 2 is empty.
3. Create a second output HEADLESS-2.
4. Unplug HEADLESS-1. Workspaces 1 and 2 are evacuated. Workspace 1 (non-empty) is moved to HEADLESS-2. Workspace 2 (empty and inactive) is destroyed.
5. Focus Workspace 3 on HEADLESS-2, making Workspace 1 inactive.
6. Move Window 1 from Workspace 1 to Workspace 3. This empties Workspace 1, triggering its destruction. During destruction, it attempts to access its sibling Workspace 2 to clean up split state, causing a use-after-free crash since Workspace 2 was already destroyed.