### PR TITLE
Fix UAF and ABA risks in space restore and extract view

### DIFF
--- a/include/sway/tree/space.h
+++ b/include/sway/tree/space.h
@@ -11,6 +11,7 @@ enum sway_space_restore {
 
 struct sway_space_view {
     struct sway_view *view;
+    struct wl_listener view_unmap;
     struct sway_space_container *container;
 	float content_scale;
 };

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -1559,10 +1559,6 @@ json_object *ipc_json_describe_trails() {
 	return object;
 }
 
-static bool find_view(struct sway_container *container, void *data) {
-	struct sway_view *view = data;
-	return container->view == view;
-}
 
 static json_object *ipc_json_describe_space_container(struct sway_space_container *space_container) {
 	json_object *object = json_object_new_object();
@@ -1576,23 +1572,25 @@ static json_object *ipc_json_describe_space_container(struct sway_space_containe
 	}
 	if (space_container->view) {
 		struct sway_view *view = space_container->view->view;
-		struct sway_container *container = root_find_container(find_view, view);
-		if (container) {
-			json_object *json_view = json_object_new_object();
-			json_object_object_add(json_view, "con_id", json_object_new_int64(container->node.id));
+		if (view) {
+			struct sway_container *container = view->container;
+			if (container) {
+				json_object *json_view = json_object_new_object();
+				json_object_object_add(json_view, "con_id", json_object_new_int64(container->node.id));
 
-			const char *identifier = view_get_class(view);
-			if (!identifier) {
-				const char *app_id = view_get_app_id(view);
-				json_object_object_add(json_view, "app_id",	app_id ? json_object_new_string(app_id) : NULL);
-			} else {
-				json_object_object_add(json_view, "class", json_object_new_string(identifier));
+				const char *identifier = view_get_class(view);
+				if (!identifier) {
+					const char *app_id = view_get_app_id(view);
+					json_object_object_add(json_view, "app_id",	app_id ? json_object_new_string(app_id) : NULL);
+				} else {
+					json_object_object_add(json_view, "class", json_object_new_string(identifier));
+				}
+				const char *title = view_get_title(view);
+				if (title) {
+					json_object_object_add(json_view, "title", json_object_new_string(title));
+				}
+				json_object_object_add(object, "view", json_view);
 			}
-			const char *title = view_get_title(view);
-			if (title) {
-				json_object_object_add(json_view, "title", json_object_new_string(title));
-			}
-			json_object_object_add(object, "view", json_view);
 		}
 	}
 

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -1111,13 +1111,10 @@ static void insert_children_relative(struct sway_container *container, struct sw
 
 static struct sway_container *extract_view(struct sway_container *view) {
 	struct sway_container *parent = view->pending.parent;
-	list_t *siblings = parent->pending.children;
-	int idx = list_find(siblings, view);
-	list_del(siblings, idx);
-	container_detach_update_parent_fullscreen_layout(parent, view);
-	container_update_representation(parent);
-	node_set_dirty(&parent->node);
-	container_reap_empty(parent);
+	container_detach(view);
+	if (parent) {
+		container_reap_empty(parent);
+	}
 	return view;
 }
 

--- a/sway/tree/space.c
+++ b/sway/tree/space.c
@@ -1,29 +1,24 @@
 #include "sway/tree/space.h"
 #include "sway/tree/workspace.h"
+#include "sway/tree/node.h"
 #include "sway/tree/arrange.h"
 #include "sway/output.h"
 
-static bool find_view(struct sway_container *container, void *data) {
-	struct sway_view *view = data;
-	return container->view == view;
+static void handle_view_unmap(struct wl_listener *listener, void *data) {
+	struct sway_space_view *view = wl_container_of(listener, view, view_unmap);
+	view->view = NULL;
+	wl_list_remove(&view->view_unmap.link);
+	wl_list_init(&view->view_unmap.link);
 }
 
-// Find the view. If it exists, detach its container and return it. If it
-// doesn't, return NULL
-static struct sway_container *find_and_detach_container(struct sway_view *view) {
-	struct sway_container *container = root_find_container(find_view, view);
-	if (container) {
-		if (!container_is_floating(container)) {
-			struct sway_container *parent = container->pending.parent;
-			list_t *siblings = parent->pending.children;
-			list_del(siblings, list_find(siblings, container));
-			node_set_dirty(&parent->pending.workspace->node);
-			container_update_representation(parent);
-			node_set_dirty(&parent->node);
+static void detach_container(struct sway_container *container) {
+	if (!container_is_floating(container)) {
+		struct sway_container *parent = container->pending.parent;
+		container_detach(container);
+		if (parent) {
 			container_reap_empty(parent);
 		}
 	}
-	return container;
 }
 
 static void fill_container(struct sway_space_container *space_container,
@@ -79,8 +74,10 @@ static struct sway_container *layout_space_container_restore_tiling(struct sway_
 	}
 	if (space_container->view) {
 		// Find view, detach its container
-		struct sway_container *container = find_and_detach_container(space_container->view->view);
+		struct sway_view *view = space_container->view->view;
+		struct sway_container *container = view ? view->container : NULL;
 		if (container) {
+			detach_container(container);
 			if (container->scratchpad) {
 				root_scratchpad_show(container);
 				root_scratchpad_remove_container(container);
@@ -90,14 +87,14 @@ static struct sway_container *layout_space_container_restore_tiling(struct sway_
 				list_del(ws->floating, list_find(ws->floating, container));
 				workspace_consider_destroy(ws);
 				node_set_dirty(&ws->node);
-				list_add(view_float, space_container->view->view);
+				list_add(view_float, container->view);
 			}
 			container->view->content_scale = space_container->view->content_scale;
 			container->pending.workspace = parent->pending.workspace;
+			container->pending.parent = parent;
 			arrange_container(container);
 			node_set_dirty(&container->node);
 			list_add(parent->pending.children, container);
-			container->pending.parent = parent;
 			fill_container(space_container, container);
 			container_update_representation(container);
 			node_set_dirty(&parent->node);
@@ -120,8 +117,10 @@ static void layout_space_container_restore_floating(struct sway_workspace *works
 		struct sway_space_container *focused, list_t *view_float) {
 	if (space_container->view) {
 		// Find view, detach its container
-		struct sway_container *container = find_and_detach_container(space_container->view->view);
+		struct sway_view *view = space_container->view->view;
+		struct sway_container *container = view ? view->container : NULL;
 		if (container) {
+			detach_container(container);
 			if (container->scratchpad) {
 				root_scratchpad_show(container);
 				root_scratchpad_remove_container(container);
@@ -135,11 +134,11 @@ static void layout_space_container_restore_floating(struct sway_workspace *works
 				list_add(view_float, container->view);
 			}
 			container->view->content_scale = space_container->view->content_scale;
+			container->pending.parent = NULL;
+			container->pending.workspace = workspace;
 			arrange_container(container);
 			node_set_dirty(&container->node);
 			list_add(workspace->floating, container);
-			container->pending.parent = NULL;
-			container->pending.workspace = workspace;
 			fill_container(space_container, container);
 			container_update_representation(container);
 		}
@@ -163,7 +162,7 @@ static bool container_find_view(struct sway_space_container *container,
 				return true;
 			}
 		}
-	} else if (container->view->view == view) {
+	} else if (container->view && container->view->view == view) {
 		return true;
 	}
 	return false;
@@ -255,10 +254,15 @@ static struct sway_space_view *space_view_create(struct sway_view *sway_view,
 	view->view = sway_view;
 	view->container = container;
 	view->content_scale = content_scale;
+	view->view_unmap.notify = handle_view_unmap;
+	wl_signal_add(&sway_view->events.unmap, &view->view_unmap);
 	return view;
 }
 
 static void space_view_destroy(struct sway_space_view *view) {
+	if (view->view) {
+		wl_list_remove(&view->view_unmap.link);
+	}
 	free(view);
 }
 

--- a/tests/test_move_cleanup_crash.py
+++ b/tests/test_move_cleanup_crash.py
@@ -1,0 +1,42 @@
+import time
+from conftest import ScrollInstance
+from test_utils import wayland_client, wait_for_client_map
+
+
+def test_move_cleanup_uaf_crash(fresh_compositor: ScrollInstance) -> None:
+    # 1. Open Window 1 on Workspace 1
+    with wayland_client(fresh_compositor, "Window 1"):
+        wait_for_client_map(fresh_compositor, "Window 1")
+
+        # Make Window 1 floating
+        res = fresh_compositor.cmd("floating enable")
+        assert res and res[0]["success"], f"floating enable failed: {res}"
+
+        # 2. Switch to Workspace 3 (so Workspace 1 becomes inactive)
+        res = fresh_compositor.cmd("workspace 3")
+        assert res and res[0]["success"], f"workspace 3 failed: {res}"
+
+        time.sleep(0.5)
+
+        # 3. Use criteria to move Window 1 from Workspace 1 to Workspace 2.
+        # This should make Workspace 1 empty and inactive, so it gets destroyed.
+        # Then the move command cleanup code should UAF on Workspace 1.
+        try:
+            res = fresh_compositor.cmd(
+                '[title="Window 1"] move container to workspace 2'
+            )
+            assert res and res[0]["success"], f"move failed: {res}"
+        except Exception as e:
+            print(f"Compositor log:\n{fresh_compositor.read_log()}")
+            raise e
+
+        # Check if compositor process is still alive
+        log_content = fresh_compositor.read_log()
+        print(f"Compositor log:\n{log_content}")
+        if (
+            fresh_compositor.proc.poll() is not None
+            or "node_table not initialized" in log_content
+        ):
+            pass
+
+        assert fresh_compositor.proc.poll() is None, "Compositor crashed"

--- a/tests/test_space_aba.py
+++ b/tests/test_space_aba.py
@@ -1,0 +1,41 @@
+import time
+from conftest import ScrollInstance
+from test_utils import wayland_client, wait_for_client_map
+
+
+def test_space_aba(fresh_compositor: ScrollInstance) -> None:
+    # 1. Create client1 on WS 1
+    with wayland_client(fresh_compositor, "client1"):
+        wait_for_client_map(fresh_compositor, "client1")
+
+        # Save space "sp1"
+        fresh_compositor.cmd("space_save sp1")
+
+    # client1 is closed now.
+    # Wait for it to be fully destroyed.
+    time.sleep(0.2)
+
+    # 2. Create client2 on WS 1.
+    # Hopefully it reuses client1's view struct address.
+    with wayland_client(fresh_compositor, "client2"):
+        wait_for_client_map(fresh_compositor, "client2")
+
+        # Switch to WS 2
+        fresh_compositor.cmd("workspace 2")
+
+        # Load space "sp1" on WS 2.
+        # If ABA bug occurs, it might find client2 (matching old client1 address)
+        # and move it to WS 2.
+        fresh_compositor.cmd("space_load sp1 load")
+
+        # Check if client2 is visible on WS 2.
+        # If it was moved to WS 2, it should be focused because space_load focuses restored containers.
+        focused_title = fresh_compositor.execute_lua("""
+            local view = scroll.focused_view()
+            return view and scroll.view_get_title(view)
+        """)
+        print(f"Focused title after space_load: {focused_title}")
+
+        assert focused_title != "client2", (
+            "ABA bug: client2 was incorrectly moved to WS 2!"
+        )

--- a/tests/test_space_crash.py
+++ b/tests/test_space_crash.py
@@ -1,0 +1,83 @@
+from conftest import ScrollInstance
+from test_utils import wayland_client, wait_for_client_map
+
+
+def test_space_restore_uaf_crash(fresh_compositor: ScrollInstance) -> None:
+    # 1. Open Window 1 on Workspace 1
+    with wayland_client(fresh_compositor, "Window 1"):
+        wait_for_client_map(fresh_compositor, "Window 1")
+
+        # Make Window 1 floating
+        res = fresh_compositor.cmd("floating enable")
+        assert res and res[0]["success"], f"floating enable failed: {res}"
+
+        # Save layout "space1" on Workspace 1
+        res = fresh_compositor.cmd("space save space1")
+        assert res and res[0]["success"], f"space save failed: {res}"
+
+        # 2. Switch to Workspace 2
+        res = fresh_compositor.cmd("workspace 2")
+        assert res and res[0]["success"], f"workspace 2 failed: {res}"
+
+        # Move Window 1 to Workspace 2
+        # (It should still be floating? Yes, moving floating window to workspace works)
+        # Actually, we can just move it.
+        # Wait, if we are on Workspace 2, we can't easily move it here unless we focus it.
+        # But we switched to Workspace 2, so focus is on Workspace 2 (empty).
+        # We should go back to Workspace 1, move it to Workspace 2, then go to Workspace 2.
+        res = fresh_compositor.cmd("workspace 1")
+        assert res and res[0]["success"], f"workspace 1 failed: {res}"
+
+        res = fresh_compositor.cmd("move container to workspace 2")
+        assert res and res[0]["success"], f"move to ws 2 failed: {res}"
+
+        res = fresh_compositor.cmd("workspace 2")
+        assert res and res[0]["success"], f"workspace 2 failed: {res}"
+
+        # Now Window 1 is floating on Workspace 2.
+        # We must make it tiled on Workspace 2.
+        res = fresh_compositor.cmd("floating disable")
+        assert res and res[0]["success"], f"floating disable failed: {res}"
+
+        # Set mode to vertical to stack next window
+        res = fresh_compositor.cmd("set_mode v")
+        assert res and res[0]["success"], f"set_mode v failed: {res}"
+
+        # Open Window 2 on Workspace 2
+        with wayland_client(fresh_compositor, "Window 2"):
+            wait_for_client_map(fresh_compositor, "Window 2")
+
+            # Now we have on Workspace 2: Split (V) -> [Window 1, Window 2]
+
+            # Move Window 2 to Workspace 3 (so Window 1 is only child of V-split)
+            res = fresh_compositor.cmd("move container to workspace 3")
+            assert res and res[0]["success"], f"move to ws 3 failed: {res}"
+
+            # Now Window 1 is the only child of V-split on Workspace 2.
+            # Workspace 2 has no other windows.
+
+            # 3. Go to Workspace 1
+            res = fresh_compositor.cmd("workspace 1")
+            assert res and res[0]["success"], f"workspace 1 failed: {res}"
+
+            # 4. Restore layout "space1"
+            # This should try to restore Window 1 as floating on Workspace 1.
+            # It will detach Window 1 from Workspace 2, reaping V-split and destroying Workspace 2.
+            # Then it will call arrange_container with dangling Workspace 2 pointer.
+            try:
+                res = fresh_compositor.cmd("space restore space1")
+                assert res and res[0]["success"], f"space restore failed: {res}"
+            except Exception as e:
+                print(f"Compositor log:\n{fresh_compositor.read_log()}")
+                raise e
+
+            # Check if compositor process is still alive
+            log_content = fresh_compositor.read_log()
+            print(f"Compositor log:\n{log_content}")
+            if (
+                fresh_compositor.proc.poll() is not None
+                or "node_table not initialized" in log_content
+            ):
+                pass
+
+            assert fresh_compositor.proc.poll() is None, "Compositor crashed"

--- a/tests/test_workspace_split_uaf.py
+++ b/tests/test_workspace_split_uaf.py
@@ -1,0 +1,59 @@
+import time
+from conftest import ScrollInstance
+from test_utils import wayland_client, wait_for_client_map
+
+
+def test_workspace_split_uaf_crash(fresh_compositor: ScrollInstance) -> None:
+    try:
+        # 1. Open Window 1 on Workspace 1 (active on HEADLESS-1)
+        with wayland_client(fresh_compositor, "Window 1"):
+            wait_for_client_map(fresh_compositor, "Window 1")
+
+            # 2. Split workspace 1. This creates workspace 2 as sibling.
+            # Workspace 1 has Window 1, Workspace 2 is empty.
+            res = fresh_compositor.cmd("workspace split")
+            assert res and res[0]["success"], f"workspace split failed: {res}"
+
+            # 3. Create a second output HEADLESS-2.
+            # It should get a default workspace (probably 3).
+            res = fresh_compositor.cmd("create_output")
+            assert res and res[0]["success"], f"create_output failed: {res}"
+
+            time.sleep(0.5)
+
+            # 4. Unplug HEADLESS-1.
+            # Workspaces 1 and 2 should be evacuated.
+            # Workspace 1 (non-empty) is moved to HEADLESS-2.
+            # Workspace 2 (empty) is destroyed.
+            res = fresh_compositor.cmd("output HEADLESS-1 unplug")
+            assert res and res[0]["success"], f"unplug failed: {res}"
+
+            time.sleep(0.5)
+
+            # 5. Focus Workspace 3 on HEADLESS-2 (so Workspace 1 becomes inactive)
+            res = fresh_compositor.cmd("workspace 3")
+            assert res and res[0]["success"], f"workspace 3 failed: {res}"
+
+            time.sleep(0.5)
+
+            # 6. Move Window 1 from Workspace 1 to Workspace 3.
+            # Since Window 1 is moved out of Workspace 1, and Workspace 1 is inactive,
+            # it should trigger workspace_consider_destroy(Workspace 1).
+            # Workspace 1 is empty, and it is split (sibling was Workspace 2).
+            # It will try to access Workspace 2 (which is destroyed) -> UAF.
+            res = fresh_compositor.cmd(
+                '[title="Window 1"] move container to workspace 3'
+            )
+            assert res and res[0]["success"], f"move container failed: {res}"
+
+            # Check if compositor process is still alive
+            log_content = fresh_compositor.read_log()
+            print(f"Compositor log:\n{log_content}")
+            assert fresh_compositor.proc.poll() is None, "Compositor crashed"
+    except Exception as e:
+        print(f"Test failed with exception: {e}")
+        try:
+            print(f"Compositor log:\n{fresh_compositor.read_log()}")
+        except Exception as log_err:
+            print(f"Failed to read compositor log: {log_err}")
+        raise e


### PR DESCRIPTION
This commit addresses potential use-after-free (UAF) and ABA risks in layout and space code:

1. `extract_view` in `sway/tree/layout.c` is refactored to use `container_detach` instead of manual list manipulation. This ensures that parent/workspace pointers are properly cleared on detach, avoiding dangling pointers.
2. `find_and_detach_container` (now inlined/refactored) in `sway/tree/space.c` is also refactored to use `container_detach` for tiling containers.
3. `layout_space_container_restore_tiling` and `layout_space_container_restore_floating` in `sway/tree/space.c` are updated to set the container's parent/workspace pointers BEFORE calling `arrange_container`, ensuring that `arrange_container` does not access old, potentially freed parent/workspace pointers.
4. `sway_space_view` is updated to track `sway_view` lifetime using a wl_listener on the `unmap` event, nullifying the pointer when the view is unmapped. This avoids UAF and ABA problems (where a pointer address is reused after a view is destroyed) when restoring layout, without relying on a global node hash table.