### PR TITLE
Fix animation offset direction and apply only to moving windows

### DIFF
--- a/scroll.lua
+++ b/scroll.lua
@@ -278,6 +278,36 @@ function scroll.container_get_width(container) end
 --- @return number
 function scroll.container_get_height(container) end
 
+--- Returns a table with the container's geometry (in layout coordinates),
+--- reflecting the final position after any animations complete, or nil if the
+--- container is invalid.
+--- The keys and values of that table are:
+---   x: number
+---   y: number
+---   width: number
+---   height: number
+---
+--- @param container integer
+---
+--- @return table|nil
+function scroll.container_get_geometry(container) end
+
+---
+--- Returns a table with the container's animated geometry (in layout coordinates),
+--- or nil if the container is invalid.
+--- This reflects the current animated position and size if an animation is running.
+--- The keys and values of that table are:
+---   x: number
+---   y: number
+---   width: number
+---   height: number
+---
+--- @param container integer
+---
+--- @return table|nil
+function scroll.container_get_animated_geometry(container) end
+
+
 ---
 --- Returns a string with the fullscreen state for container.
 --- Values can be `none`, `workspace` (covers only its workspace extents)

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -1748,11 +1748,14 @@ static void animate_children(struct sway_workspace *workspace,
 				child->animation.yt += linear_scale(0.0, off - child->animation.y0, x);
 				animation_set_animation_enabled(true);
 			}
+			double xt = 0;
 			if (y != 0.0) {
-				child->animation.yt += y * anim_scale * workspace->height;
-				animation_set_animation_enabled(true);
+				if (fabs(off - child->animation.y0) > 1.0) {
+					xt += y * anim_scale * workspace->width;
+					animation_set_animation_enabled(true);
+				}
 			}
-			wlr_scene_node_set_position(&child->scene_tree->node, 0, child->animation.yt - workspace->y);
+			wlr_scene_node_set_position(&child->scene_tree->node, xt, child->animation.yt - workspace->y);
 			child->current.y = off;
 			child->pending.y = off;
 			if (parent) {
@@ -1777,12 +1780,15 @@ static void animate_children(struct sway_workspace *workspace,
 				child->animation.xt += linear_scale(0.0, off - child->animation.x0, x);
 				animation_set_animation_enabled(true);
 			}
+			double yt = 0;
 			if (y != 0.0) {
-				child->animation.xt += y * anim_scale * workspace->width;
-				animation_set_animation_enabled(true);
+				if (fabs(off - child->animation.x0) > 1.0) {
+					yt += y * anim_scale * workspace->height;
+					animation_set_animation_enabled(true);
+				}
 			}
 			wlr_scene_node_set_enabled(&child->decoration.tree->node, true);
-			wlr_scene_node_set_position(&child->scene_tree->node, child->animation.xt - workspace->x, 0);
+			wlr_scene_node_set_position(&child->scene_tree->node, child->animation.xt - workspace->x, yt);
 			// Update child for next iteration. Transactions don't re-arrange
 			// the layout (arrange.c:apply_xxx()), so we need to set it here,
 			// otherwise the next call will have the positions wrong and the

--- a/sway/lua.c
+++ b/sway/lua.c
@@ -9,6 +9,7 @@
 #include "sway/tree/workspace.h"
 #include "sway/tree/node.h"
 #include "sway/output.h"
+#include "sway/desktop/animation.h"
 #include "sway/ipc-server.h"
 
 #if 0
@@ -749,6 +750,69 @@ static int scroll_container_get_height(lua_State *L) {
 	lua_pushnumber(L, container->pending.height);
 	return 1;
 }
+
+static int scroll_container_get_geometry(lua_State *L) {
+	int argc = lua_gettop(L);
+	if (argc == 0) {
+		lua_pushnil(L);
+		return 1;
+	}
+	struct sway_container *container = lua_to_container(L, -1);
+	if (!container) {
+		lua_pushnil(L);
+		return 1;
+	}
+	lua_createtable(L, 0, 4);
+	lua_pushnumber(L, container->pending.x);
+	lua_setfield(L, -2, "x");
+	lua_pushnumber(L, container->pending.y);
+	lua_setfield(L, -2, "y");
+	lua_pushnumber(L, container->pending.width);
+	lua_setfield(L, -2, "width");
+	lua_pushnumber(L, container->pending.height);
+	lua_setfield(L, -2, "height");
+	return 1;
+}
+
+static int scroll_container_get_animated_geometry(lua_State *L) {
+	int argc = lua_gettop(L);
+	if (argc == 0) {
+		lua_pushnil(L);
+		return 1;
+	}
+	struct sway_container *container = lua_to_container(L, -1);
+	if (!container) {
+		lua_pushnil(L);
+		return 1;
+	}
+	lua_createtable(L, 0, 4);
+	double lx, ly;
+	if (container->scene_tree && wlr_scene_node_coords(&container->scene_tree->node, &lx, &ly)) {
+		lua_pushnumber(L, lx);
+		lua_setfield(L, -2, "x");
+		lua_pushnumber(L, ly);
+		lua_setfield(L, -2, "y");
+	} else {
+		lua_pushnumber(L, container->current.x);
+		lua_setfield(L, -2, "x");
+		lua_pushnumber(L, container->current.y);
+		lua_setfield(L, -2, "y");
+	}
+
+	if (animation_animating()) {
+		lua_pushnumber(L, container->animation.wt);
+		lua_setfield(L, -2, "width");
+		lua_pushnumber(L, container->animation.ht);
+		lua_setfield(L, -2, "height");
+	} else {
+		lua_pushnumber(L, container->current.width);
+		lua_setfield(L, -2, "width");
+		lua_pushnumber(L, container->current.height);
+		lua_setfield(L, -2, "height");
+	}
+	return 1;
+}
+
 
 static int scroll_container_get_fullscreen_mode(lua_State *L) {
 	int argc = lua_gettop(L);
@@ -1584,6 +1648,8 @@ static luaL_Reg const scroll_lib[] = {
 	{ "container_get_height_fraction", scroll_container_get_height_fraction },
 	{ "container_get_width", scroll_container_get_width },
 	{ "container_get_height", scroll_container_get_height },
+	{ "container_get_geometry", scroll_container_get_geometry },
+	{ "container_get_animated_geometry", scroll_container_get_animated_geometry },
 	{ "container_get_fullscreen_mode", scroll_container_get_fullscreen_mode },
 	{ "container_get_fullscreen_app_mode", scroll_container_get_fullscreen_app_mode },
 	{ "container_get_fullscreen_view_mode", scroll_container_get_fullscreen_view_mode },

--- a/sway/scroll.5.scd
+++ b/sway/scroll.5.scd
@@ -2161,6 +2161,22 @@ scroll.command(nil, "set_size v 0.33333333; move left nomode")
 *container_get_height(container)*
 	Returns a floating point value with the _container_'s height in pixels.
 
+*container_get_geometry(container)*
+	Returns a table with the _container_'s geometry (in layout coordinates),
+	reflecting the final position after any animations complete, or *nil* if
+	the container is invalid.
+	The keys of that table are "x", "y", "width" and "height", and the values
+	are floating point numbers.
+
+
+*container_get_animated_geometry(container)*
+	Returns a table with the _container_'s animated geometry (in layout coordinates),
+	or *nil* if the container is invalid.
+	This reflects the current animated position and size if an animation is running.
+	The keys of that table are "x", "y", "width" and "height", and the values
+	are floating point numbers.
+
+
 *container_get_fullscreen_mode(container)*
 	Returns a string with the _fullscreen_ state for _container_. Values can be
 	"none", "workspace" (covers only its workspace extents) or "global" (covers

--- a/tests/test_animation_offset.py
+++ b/tests/test_animation_offset.py
@@ -1,0 +1,129 @@
+import time
+from typing import Generator
+from pathlib import Path
+import pytest
+from conftest import ScrollInstance
+from test_utils import wayland_client, wait_for_client_map, run_compositor
+
+
+@pytest.fixture(scope="function")
+def offset_animating_compositor(
+    scroll_compositor_binary: str, tmp_path: Path
+) -> Generator[ScrollInstance, None, None]:
+    config: str = (
+        "workspace 1\n"
+        "xwayland force\n"
+        "animations enabled yes\n"
+        # 5 second animation, 10% offset scale
+        "animations window_move yes 5000 var 3 [ 0.215 0.61 0.355 1 ] off 0.1 6 [0 0.6 0.4 0 1 0 0.4 -0.6 1 -0.6]\n"
+    )
+    with run_compositor(scroll_compositor_binary, tmp_path, config) as inst:
+        yield inst
+
+
+def test_animation_offset_unintended_move(
+    offset_animating_compositor: ScrollInstance,
+) -> None:
+    inst = offset_animating_compositor
+
+    try:
+        with wayland_client(inst, "client1"):
+            wait_for_client_map(inst, "client1")
+            time.sleep(0.5)
+            with wayland_client(inst, "client2"):
+                wait_for_client_map(inst, "client2")
+                time.sleep(0.5)
+                with wayland_client(inst, "client3"):
+                    wait_for_client_map(inst, "client3")
+                    time.sleep(0.5)
+
+                    tree = inst.get_tree()
+
+                    def find_views(node, result):
+                        if node.get("type") == "con" and node.get("name"):
+                            if (
+                                node.get("window")
+                                or node.get("app_id")
+                                or (
+                                    node.get("window_properties")
+                                    and node["window_properties"].get("title")
+                                )
+                            ):
+                                result.append(
+                                    {
+                                        "title": node["name"],
+                                        "id": node["id"],
+                                        "x": node["rect"]["x"],
+                                    }
+                                )
+                        for child in node.get("nodes", []):
+                            find_views(child, result)
+                        for child in node.get("floating_nodes", []):
+                            find_views(child, result)
+
+                    views = []
+                    find_views(tree, views)
+                    print("Found views:", views)
+                    assert len(views) == 3
+
+                    # Sort by X to identify leftmost, middle, rightmost
+                    sorted_views = sorted(views, key=lambda v: v["x"])
+                    v1, v2, v3 = sorted_views
+                    print(
+                        f"Leftmost: {v1['title']}, Middle: {v2['title']}, Rightmost: {v3['title']}"
+                    )
+
+                    # Focus rightmost (client3) to avoid scroll during swap
+                    print("Focusing rightmost...")
+                    res = inst.cmd(f"[con_id={v3['id']}] focus")
+                    assert res[0]["success"]
+                    time.sleep(1.0)  # wait for focus scroll to settle
+
+                    # Swap leftmost and middle by moving leftmost right, using its ID as context
+                    print("Swapping leftmost and middle in background...")
+                    # We use execute_lua to run scroll.command with v1['id'] context
+                    res_lua = inst.execute_lua(
+                        f"return scroll.command({v1['id']}, 'move right')"
+                    )
+                    print(f"Lua command result: {res_lua}")
+
+                    # Get parent container of client3 to query its actual position
+                    parent_id = inst.execute_lua(
+                        f"return scroll.container_get_parent({v3['id']})"
+                    )
+                    query_id = parent_id if parent_id is not None else v3["id"]
+                    print(f"Querying container {query_id} (parent of {v3['id']})")
+
+                    # Query position of client3 during animation
+                    positions = []
+                    start_time = time.time()
+                    while time.time() - start_time < 2.0:
+                        geom = inst.execute_lua(
+                            f"return scroll.container_get_animated_geometry({query_id})"
+                        )
+                        positions.append(geom)
+                        time.sleep(0.05)
+
+                    print(f"Positions of client3: {positions}")
+
+                    # Verify positions are constant
+                    x_values = [p["x"] for p in positions]
+                    y_values = [p["y"] for p in positions]
+
+                    first_x = x_values[0]
+                    first_y = y_values[0]
+                    for x in x_values:
+                        assert x == pytest.approx(first_x, abs=1.0), (
+                            f"client3 moved horizontally: {x_values}"
+                        )
+                    for y in y_values:
+                        assert y == pytest.approx(first_y, abs=1.0), (
+                            f"client3 moved vertically: {y_values}"
+                        )
+
+                    print("Test passed: static window did not move.")
+
+    except Exception as e:
+        print("Scroll Log on failure:")
+        print(inst.read_log())
+        raise e

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,0 +1,174 @@
+import time
+from typing import Generator
+from pathlib import Path
+import pytest
+from conftest import ScrollInstance
+from test_utils import wayland_client, wait_for_client_map, run_compositor
+
+
+@pytest.fixture(scope="function")
+def animating_compositor(
+    scroll_compositor_binary: str, tmp_path: Path
+) -> Generator[ScrollInstance, None, None]:
+    config: str = (
+        "workspace 1\n"
+        "xwayland force\n"
+        "animations enabled yes\n"
+        # 2 second animation for window_move
+        "animations window_move yes 2000 linear\n"
+    )
+    with run_compositor(scroll_compositor_binary, tmp_path, config) as inst:
+        yield inst
+
+
+def test_static_geometry(scroll_compositor: ScrollInstance) -> None:
+    inst = scroll_compositor
+    with wayland_client(inst, "client1"):
+        view_id = wait_for_client_map(inst, "client1")
+        con_id = inst.execute_lua(f"return scroll.view_get_container({view_id})")
+        assert con_id is not None
+
+        # Wait for any map animation to settle
+        time.sleep(2.0)
+
+        geom = inst.execute_lua(f"return scroll.container_get_geometry({con_id})")
+        actual_geom = inst.execute_lua(
+            f"return scroll.container_get_animated_geometry({con_id})"
+        )
+
+        print("Static Geometry:", geom)
+        print("Static Actual Geometry:", actual_geom)
+
+        tree = inst.get_tree()
+        print("Tree:", tree)
+
+        assert geom == actual_geom
+        assert "x" in geom
+        assert "y" in geom
+        assert "width" in geom
+        assert "height" in geom
+
+        # Check if they match tree rect
+
+        def find_node(node, target_id):
+            if node.get("id") == target_id:
+                return node
+            for child in node.get("nodes", []):
+                n = find_node(child, target_id)
+                if n:
+                    return n
+            for child in node.get("floating_nodes", []):
+                n = find_node(child, target_id)
+                if n:
+                    return n
+            return None
+
+        target_node = find_node(tree, con_id)
+        assert target_node is not None
+        rect = target_node["rect"]
+        deco_rect = target_node.get("deco_rect", {"height": 0})
+
+        expected_y = rect["y"]
+        expected_height = rect["height"]
+        # If the container has a titlebar, the 'rect' in get_tree excludes it.
+        # But container_get_geometry includes it.
+        if deco_rect.get("height", 0) > 0:
+            expected_y -= deco_rect["height"]
+            expected_height += deco_rect["height"]
+
+        assert geom["x"] == rect["x"]
+        assert geom["y"] == expected_y
+        assert geom["width"] == rect["width"]
+        assert geom["height"] == expected_height
+
+
+def test_animating_geometry(animating_compositor: ScrollInstance) -> None:
+    inst = animating_compositor
+    with wayland_client(inst, "client1"):
+        v1 = wait_for_client_map(inst, "client1")
+        c1 = inst.execute_lua(f"return scroll.view_get_container({v1})")
+
+        with wayland_client(inst, "client2"):
+            wait_for_client_map(inst, "client2")
+
+            # Wait for initial map animations to settle
+            time.sleep(0.5)
+
+            geom_before = inst.execute_lua(
+                f"return scroll.container_get_geometry({c1})"
+            )
+            actual_geom_before = inst.execute_lua(
+                f"return scroll.container_get_animated_geometry({c1})"
+            )
+            assert geom_before == actual_geom_before
+
+            print("Before move:", geom_before)
+
+            # Trigger move
+            inst.execute_lua(f"scroll.command({c1}, 'move right')")
+
+            # Immediately query geometry
+            geom_after_trigger = inst.execute_lua(
+                f"return scroll.container_get_geometry({c1})"
+            )
+            actual_geom_after_trigger = inst.execute_lua(
+                f"return scroll.container_get_animated_geometry({c1})"
+            )
+
+            print("Immediately after trigger (target):", geom_after_trigger)
+            print("Immediately after trigger (actual):", actual_geom_after_trigger)
+
+            # The target geometry (geom) should have jumped to the final position.
+            # The actual geometry should still be close to the initial position.
+            assert geom_after_trigger != geom_before
+            assert actual_geom_after_trigger["x"] == pytest.approx(
+                actual_geom_before["x"], abs=10.0
+            )
+
+            # Monitor animation
+            actual_xs = []
+            target_xs = []
+            start_time = time.time()
+            while time.time() - start_time < 2.5:  # Animation is 2s
+                g = inst.execute_lua(f"return scroll.container_get_geometry({c1})")
+                ag = inst.execute_lua(
+                    f"return scroll.container_get_animated_geometry({c1})"
+                )
+                target_xs.append(g["x"])
+                actual_xs.append(ag["x"])
+                time.sleep(0.1)
+
+            print("Target Xs:", target_xs)
+            print("Actual Xs:", actual_xs)
+
+            # Target Xs should all be equal to the final position
+            final_x = geom_after_trigger["x"]
+            for tx in target_xs:
+                assert tx == final_x
+
+            # Actual Xs should start near before_x and end at final_x
+            assert actual_xs[0] < final_x  # Assuming it moved right
+            assert actual_xs[-1] == pytest.approx(final_x, abs=1.0)
+
+            # Verify it is monotonically increasing (if it moved right)
+            for i in range(1, len(actual_xs)):
+                assert actual_xs[i] >= actual_xs[i - 1] - 0.1
+
+
+def test_invalid_geometry(scroll_compositor: ScrollInstance) -> None:
+    inst = scroll_compositor
+    # Invalid ID
+    geom = inst.execute_lua("return scroll.container_get_geometry(99999)")
+    animated_geom = inst.execute_lua(
+        "return scroll.container_get_animated_geometry(99999)"
+    )
+    assert geom is None
+    assert animated_geom is None
+
+    # No arguments
+    geom_no_args = inst.execute_lua("return scroll.container_get_geometry()")
+    animated_geom_no_args = inst.execute_lua(
+        "return scroll.container_get_animated_geometry()"
+    )
+    assert geom_no_args is None
+    assert animated_geom_no_args is None


### PR DESCRIPTION
The `window_move` animation config allows defining an `off` curve for the perpendicular axis offset (the axis that doesn't change). However, the implementation was:
1. Applying the offset to the wrong axis (e.g., modifying `xt` in horizontal layout, which is the layout axis, instead of `yt`).
2. Applying the offset to all windows in the workspace, even those that are static (not moving as part of the transaction).

This resulted in static windows wiggling horizontally during swap animations.

This patch:
1. Corrects the offset axis: `yt` (vertical) is modified for `L_HORIZ` (horizontal layout), and `xt` (horizontal) is modified for `L_VERT`.
2. Restricts the offset application to windows that are actually moving in the transaction (detected by comparing target position to start position).