### PR TITLE
Implement alignment options and policies for scroller layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -779,7 +779,7 @@ At window creation time, *scroll* can apply several modifiers to the
 current working mode (*h/v*). `set_mode` supports extra arguments:
 
 ``` config
-set_mode [<h|v|t> <after|before|end|beg> <focus|nofocus> <center_horiz|nocenter_horiz> <center_vert|nocenter_vert> <reorder_auto|noreorder_auto>]
+set_mode [<h|v|t> <after|before|end|beg> <focus|nofocus> <center_horiz|nocenter_horiz> <center_vert|nocenter_vert> <reorder_auto|noreorder_auto> <align_horiz_initial|align_horiz_if_fits> <align_vert_initial|align_vert_if_fits> <align_horiz_left|align_horiz_center|align_horiz_right> <align_vert_top|align_vert_middle|align_vert_bottom>]
 ```
 
 1. `<h|v|t>`: set horizontal, vertical, or toggle the current mode.
@@ -799,8 +799,12 @@ mode to `noreorder_auto`, and the window will keep its position regardless of
 what you do, until you set `reorder_auto` again.
 5. `center_horiz/nocenter_horiz`: It will keep the active column centered
 (or not) on the screen. The default value is the one in your configuration.
-4. `center_vert/nocenter_vert`: It will keep the active window centered
+6. `center_vert/nocenter_vert`: It will keep the active window centered
 (or not) in its column. The default value is the one in your configuration.
+7. `align_horiz_<left|center|right>`: Set alignment for horizontal mode when all windows fit.
+8. `align_vert_<top|middle|bottom>`: Set alignment for vertical mode when all windows fit.
+9. `align_horiz_<initial|if_fits>`: Set alignment policy for horizontal mode. `initial` only aligns the first window and then preserves positions; `if_fits` always aligns when they fit.
+10. `align_vert_<initial|if_fits>`: Set alignment policy for vertical mode.
 
 You can skip any number of parameters when calling the command, and their
 order doesn't matter.

--- a/include/sway/tree/layout.h
+++ b/include/sway/tree/layout.h
@@ -76,6 +76,23 @@ enum sway_layout_filter {
 	LAYOUT_FILTER_SCRATCHPAD,
 };
 
+enum sway_layout_align_horiz {
+	ALIGN_HORIZ_LEFT,
+	ALIGN_HORIZ_CENTER,
+	ALIGN_HORIZ_RIGHT,
+};
+
+enum sway_layout_align_vert {
+	ALIGN_VERT_TOP,
+	ALIGN_VERT_MIDDLE,
+	ALIGN_VERT_BOTTOM,
+};
+
+enum sway_layout_align_policy {
+	ALIGN_POLICY_IF_FIT,
+	ALIGN_POLICY_INITIAL,
+};
+
 struct sway_scroller {
 	enum sway_container_layout type;
 
@@ -86,6 +103,10 @@ struct sway_scroller {
 		bool focus;
 		bool center_horizontal;
 		bool center_vertical;
+		enum sway_layout_align_horiz align_horiz;
+		enum sway_layout_align_vert align_vert;
+		enum sway_layout_align_policy align_horiz_policy;
+		enum sway_layout_align_policy align_vert_policy;
 	} modifiers;
 
 	enum sway_layout_overview overview;
@@ -118,6 +139,14 @@ struct sway_scroller_modifiers {
 	bool center_horizontal;
 	bool center_vertical_set;
 	bool center_vertical;
+	bool align_horiz_set;
+	enum sway_layout_align_horiz align_horiz;
+	bool align_vert_set;
+	enum sway_layout_align_vert align_vert;
+	bool align_horiz_policy_set;
+	enum sway_layout_align_policy align_horiz_policy;
+	bool align_vert_policy_set;
+	enum sway_layout_align_policy align_vert_policy;
 };
 
 struct sway_scroller_output_options {
@@ -173,6 +202,14 @@ void layout_modifiers_set_focus(struct sway_workspace *workspace, bool focus);
 void layout_modifiers_set_center_horizontal(struct sway_workspace *workspace, bool center);
 void layout_modifiers_set_center_vertical(struct sway_workspace *workspace, bool center);
 void layout_modifiers_set_reorder(struct sway_workspace *workspace, enum sway_layout_reorder reorder);
+void layout_modifiers_set_align_horiz(
+		struct sway_workspace *workspace, enum sway_layout_align_horiz align);
+void layout_modifiers_set_align_vert(
+		struct sway_workspace *workspace, enum sway_layout_align_vert align);
+void layout_modifiers_set_align_horiz_policy(
+		struct sway_workspace *workspace, enum sway_layout_align_policy policy);
+void layout_modifiers_set_align_vert_policy(
+		struct sway_workspace *workspace, enum sway_layout_align_policy policy);
 
 enum sway_container_layout layout_modifiers_get_mode(struct sway_workspace *workspace);
 enum sway_layout_insert layout_modifiers_get_insert(struct sway_workspace *workspace);
@@ -180,6 +217,12 @@ bool layout_modifiers_get_focus(struct sway_workspace *workspace);
 bool layout_modifiers_get_center_horizontal(struct sway_workspace *workspace);
 bool layout_modifiers_get_center_vertical(struct sway_workspace *workspace);
 enum sway_layout_reorder layout_modifiers_get_reorder(struct sway_workspace *workspace);
+enum sway_layout_align_horiz layout_modifiers_get_align_horiz(struct sway_workspace *workspace);
+enum sway_layout_align_vert layout_modifiers_get_align_vert(struct sway_workspace *workspace);
+enum sway_layout_align_policy layout_modifiers_get_align_horiz_policy(
+		struct sway_workspace *workspace);
+enum sway_layout_align_policy layout_modifiers_get_align_vert_policy(
+		struct sway_workspace *workspace);
 
 // Layout API
 void layout_add_view(struct sway_workspace *workspace, struct sway_container *active, struct sway_container *view);

--- a/scroll.lua
+++ b/scroll.lua
@@ -440,6 +440,10 @@ function scroll.workspace_get_floating(workspace) end
 ---   focus: true|false
 ---   center_horizontal: true|false
 ---   center_vertical: true|false
+---   align_horiz: "left"|"center"|"right"
+---   align_vert: "top"|"middle"|"bottom"
+---   align_horiz_policy: "initial"|"if_fits"
+---   align_vert_policy: "initial"|"if_fits"
 ---
 --- @param workspace integer
 ---
@@ -457,6 +461,10 @@ function scroll.workspace_get_mode(workspace) end
 ---   focus: true|false
 ---   center_horizontal: true|false
 ---   center_vertical: true|false
+---   align_horiz: "left"|"center"|"right"
+---   align_vert: "top"|"middle"|"bottom"
+---   align_horiz_policy: "initial"|"if_fits"
+---   align_vert_policy: "initial"|"if_fits"
 ---
 --- @param workspace integer
 --- @param modifiers table

--- a/sway/commands/align.c
+++ b/sway/commands/align.c
@@ -22,9 +22,9 @@ static bool parse_direction(const char *name,
 		*out = DIR_LEFT;
 	} else if (strcasecmp(name, "right") == 0) {
 		*out = DIR_RIGHT;
-	} else if (strcasecmp(name, "up") == 0) {
+	} else if (strcasecmp(name, "up") == 0 || strcasecmp(name, "top") == 0) {
 		*out = DIR_UP;
-	} else if (strcasecmp(name, "down") == 0) {
+	} else if (strcasecmp(name, "down") == 0 || strcasecmp(name, "bottom") == 0) {
 		*out = DIR_DOWN;
 	} else if (strcasecmp(name, "center") == 0) {
 		*out = DIR_CENTER;
@@ -103,9 +103,10 @@ struct cmd_results *cmd_align(int argc, char **argv) {
 
 	enum sway_layout_direction direction = DIR_INVALID;
 	if (!parse_direction(argv[0], &direction)) {
-		return cmd_results_new(CMD_INVALID, "Expected 'align <left|right|center|up|down|middle|reset>' ");
+		return cmd_results_new(
+				CMD_INVALID, "Expected 'align <left|right|center|top|bottom|middle|reset>' ");
 	}
-	
+
 	enum sway_container_layout layout = layout_get_type(workspace);
 	enum sway_container_layout mode = layout_modifiers_get_mode(workspace);
 	struct sway_container *parent = container->pending.parent ? container->pending.parent : container;

--- a/sway/commands/set_mode.c
+++ b/sway/commands/set_mode.c
@@ -4,7 +4,10 @@
 #include <string.h>
 #include <strings.h>
 #include <wlr/util/edges.h>
+
 #include "sway/commands.h"
+#include "sway/desktop/transaction.h"
+#include "sway/tree/arrange.h"
 #include "sway/tree/workspace.h"
 
 struct cmd_results *cmd_set_mode(int argc, char **argv) {
@@ -93,16 +96,62 @@ struct cmd_results *cmd_set_mode(int argc, char **argv) {
 			layout_modifiers_set_reorder(current, REORDER_LAZY);
 			success = true;
 		}
+
+		if (strcasecmp(argv[i], "align_horiz_initial") == 0) {
+			layout_modifiers_set_align_horiz_policy(current, ALIGN_POLICY_INITIAL);
+			success = true;
+		} else if (strcasecmp(argv[i], "align_horiz_if_fits") == 0) {
+			layout_modifiers_set_align_horiz_policy(current, ALIGN_POLICY_IF_FIT);
+			success = true;
+		}
+		if (strcasecmp(argv[i], "align_vert_initial") == 0) {
+			layout_modifiers_set_align_vert_policy(current, ALIGN_POLICY_INITIAL);
+			success = true;
+		} else if (strcasecmp(argv[i], "align_vert_if_fits") == 0) {
+			layout_modifiers_set_align_vert_policy(current, ALIGN_POLICY_IF_FIT);
+			success = true;
+		}
+
+		if (strcasecmp(argv[i], "align_horiz_left") == 0) {
+			layout_modifiers_set_align_horiz(current, ALIGN_HORIZ_LEFT);
+			success = true;
+		} else if (strcasecmp(argv[i], "align_horiz_center") == 0) {
+			layout_modifiers_set_align_horiz(current, ALIGN_HORIZ_CENTER);
+			success = true;
+		} else if (strcasecmp(argv[i], "align_horiz_right") == 0) {
+			layout_modifiers_set_align_horiz(current, ALIGN_HORIZ_RIGHT);
+			success = true;
+		}
+
+		if (strcasecmp(argv[i], "align_vert_top") == 0) {
+			layout_modifiers_set_align_vert(current, ALIGN_VERT_TOP);
+			success = true;
+		} else if (strcasecmp(argv[i], "align_vert_middle") == 0) {
+			layout_modifiers_set_align_vert(current, ALIGN_VERT_MIDDLE);
+			success = true;
+		} else if (strcasecmp(argv[i], "align_vert_bottom") == 0) {
+			layout_modifiers_set_align_vert(current, ALIGN_VERT_BOTTOM);
+			success = true;
+		}
 	}
 
 	if (success) {
 		if (update_container && container) {
 			container_update(container);
 		}
+		arrange_workspace(current);
+		transaction_commit_dirty();
 		return cmd_results_new(CMD_SUCCESS, NULL);
 	}
 
-	const char usage[] = "Expected 'set_mode [<h|v|t> <after|before|end|beg> <focus|nofocus> <center_horiz|nocenter_horiz> <center_vert|nocenter_vert> <reorder_auto|noreorder_auto>]'";
+	const char usage[] = "Expected 'set_mode [<h|v|t> <after|before|end|beg> "
+						 "<focus|nofocus> "
+						 "<center_horiz|nocenter_horiz> <center_vert|nocenter_vert> "
+						 "<reorder_auto|noreorder_auto> "
+						 "<align_horiz_initial|align_horiz_if_fits> "
+						 "<align_vert_initial|align_vert_if_fits> "
+						 "<align_horiz_left|align_horiz_center|align_horiz_right> "
+						 "<align_vert_top|align_vert_middle|align_vert_bottom>]'";
 
 	return cmd_results_new(CMD_INVALID, "%s", usage);
 }

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -348,7 +348,7 @@ static double get_active_position_pin(struct sway_workspace *workspace,
 			for (int i = active_idx - 1; i >= 0; i--) {
 				struct sway_container *con = children->items[i];
 				if (con != pin) {
-					double cw = scale * (con->current.width +  2.0 * gaps);
+					double cw = scale * (con->pending.width + 2.0 * gaps);
 					cx0 += cw;
 					if (cx0 + caw > workspace_end) {
 						break;
@@ -377,7 +377,7 @@ static double get_active_position_pin(struct sway_workspace *workspace,
 			for (int i = active_idx + 1; i < children->length; ++i) {
 				struct sway_container *con = children->items[i];
 				if (con != pin) {
-					double cw = scale * (con->current.width +  2.0 * gaps);
+					double cw = scale * (con->pending.width + 2.0 * gaps);
 					cx1 -= cw;
 					if (cx1 - caw < workspace_beg) {
 						break;
@@ -411,7 +411,7 @@ static double get_active_position_pin(struct sway_workspace *workspace,
 			for (int i = active_idx - 1; i >= 0; i--) {
 				struct sway_container *con = children->items[i];
 				if (con != pin) {
-					double ch = scale * (con->current.height +  2.0 * gaps);
+					double ch = scale * (con->pending.height + 2.0 * gaps);
 					cy0 += ch;
 					if (cy0 + cah > workspace_end) {
 						break;
@@ -440,7 +440,7 @@ static double get_active_position_pin(struct sway_workspace *workspace,
 			for (int i = active_idx + 1; i < children->length; ++i) {
 				struct sway_container *con = children->items[i];
 				if (con != pin) {
-					double ch = scale * (con->current.height +  2.0 * gaps);
+					double ch = scale * (con->pending.height + 2.0 * gaps);
 					cy1 -= ch;
 					if (cy1 - cah < workspace_beg) {
 						break;
@@ -465,6 +465,40 @@ static double get_active_position_pin(struct sway_workspace *workspace,
 static double get_active_position(struct sway_workspace *workspace,
 		enum sway_container_layout layout, list_t *children, int active_idx,
 		int gaps, float scale) {
+	double tsize = 0;
+	for (int i = 0; i < children->length; ++i) {
+		struct sway_container *con = children->items[i];
+		tsize +=
+				scale * ((layout == L_HORIZ ? con->pending.width : con->pending.height) + 2 * gaps);
+	}
+	tsize = round(tsize);
+
+	double wsize = layout == L_HORIZ ? workspace->width : workspace->height;
+	if (tsize <= wsize) {
+		double lsize = 0;
+		for (int i = 0; i < active_idx; ++i) {
+			struct sway_container *con = children->items[i];
+			lsize += scale *
+					((layout == L_HORIZ ? con->pending.width : con->pending.height) + 2 * gaps);
+		}
+		lsize = round(lsize);
+
+		struct sway_container *active = children->items[active_idx];
+		double active_val = layout == L_HORIZ ? active->pending.x : active->pending.y;
+		double ws_val = layout == L_HORIZ ? workspace->x : workspace->y;
+
+		double min_active = ws_val + scale * gaps + lsize;
+		double max_active = ws_val + wsize - tsize + scale * gaps + lsize;
+
+		if (active_val < min_active) {
+			return min_active;
+		} else if (active_val > max_active) {
+			return max_active;
+		} else {
+			return active_val;
+		}
+	}
+
 	// We consider all the possible positions where each container is at the
 	// left/top edge and at the right/bottom edge. We choose the one that leaves
 	// the active container inside the viewport, moves the active as little as
@@ -488,7 +522,7 @@ static double get_active_position(struct sway_workspace *workspace,
 		double x1 = workspace->x + scale * gaps;
 		for (int c = active_idx; c < children->length; ++c) {
 			struct sway_container *con = children->items[c];
-			x1 += scale * (con->current.width + gaps);
+			x1 += scale * (con->pending.width + gaps);
 			// For those that fit, locate each one at the end of the viewport,
 			// and check the previous ones don't leave any empty space.
 			if (x1 <= workspace_end) {
@@ -497,10 +531,9 @@ static double get_active_position(struct sway_workspace *workspace,
 				double movement = DBL_MAX;
 				double cx0 = workspace->x + workspace->width;
 				bool space = true;
-				bool fits = false;
 				for (int i = c_r; i >= 0; i--) {
 					struct sway_container *con = children->items[i];
-					cx0 -= scale * (con->current.width + 2.0 * gaps);
+					cx0 -= scale * (con->pending.width + 2.0 * gaps);
 					if (i == active_idx) {
 						movement = (cx0 + scale * gaps) - a_x;
 					}
@@ -510,11 +543,8 @@ static double get_active_position(struct sway_workspace *workspace,
 							break;
 						}
 					}
-					if (c_r == children->length - 1 && i == 0) {
-						fits = true;
-					}
 				}
-				if ((!space || fits) && fabs(movement) < fabs(best_movement)) {
+				if (!space && fabs(movement) < fabs(best_movement)) {
 					move = true;
 					best_movement = movement;
 				}
@@ -527,7 +557,7 @@ static double get_active_position(struct sway_workspace *workspace,
 		double x0 = workspace->x + workspace->width - scale * gaps;
 		for (int c = active_idx; c >= 0; --c) {
 			struct sway_container *con = children->items[c];
-			x0 -= scale * (con->current.width + gaps);
+			x0 -= scale * (con->pending.width + gaps);
 			// For those that fit, locate each one at the beginning of the viewport,
 			// and check the next ones don't leave any empty space.
 			if (x0 >= workspace_beg) {
@@ -536,24 +566,20 @@ static double get_active_position(struct sway_workspace *workspace,
 				double movement = DBL_MAX;
 				double cx1 = workspace->x;
 				bool space = true;
-				bool fits = false;
 				for (int i = c_l; i < children->length; ++i) {
 					if (i == active_idx) {
 						movement = (cx1 + scale * gaps) - a_x;
 					}
 					struct sway_container *con = children->items[i];
-					cx1 += scale * (con->current.width + 2.0 * gaps);
+					cx1 += scale * (con->pending.width + 2.0 * gaps);
 					if (cx1 >= workspace_end) {
 						space = false;
 						if (cx1 > workspace_end) {
 							break;
 						}
 					}
-					if (c_l == 0 && i == children->length - 1) {
-						fits = true;
-					}
 				}
-				if ((!space || fits) && fabs(movement) < fabs(best_movement)) {
+				if (!space && fabs(movement) < fabs(best_movement)) {
 					move = true;
 					best_movement = movement;
 				}
@@ -572,31 +598,27 @@ static double get_active_position(struct sway_workspace *workspace,
 		double y0 = workspace->y + workspace->height - scale * gaps;
 		for (int c = active_idx; c >= 0; --c) {
 			struct sway_container *con = children->items[c];
-			y0 -= scale * (con->current.height + gaps);
+			y0 -= scale * (con->pending.height + gaps);
 			if (y0 >= workspace_beg) {
 				c_l = c;
 				// Test from c_l to the end
 				double movement = DBL_MAX;
 				double cy1 = workspace->y;
 				bool space = true;
-				bool fits = false;
 				for (int i = c_l; i < children->length; ++i) {
 					if (i == active_idx) {
 						movement = (cy1 + scale * gaps) - a_y;
 					}
 					struct sway_container *con = children->items[i];
-					cy1 += scale * (con->current.height + 2.0 * gaps);
+					cy1 += scale * (con->pending.height + 2.0 * gaps);
 					if (cy1 >= workspace_end) {
 						space = false;
 						if (cy1 > workspace_end) {
 							break;
 						}
 					}
-					if (c_l == 0 && i == children->length - 1) {
-						fits = true;
-					}
 				}
-				if ((!space || fits) &&	fabs(movement) < fabs(best_movement)) {
+				if (!space && fabs(movement) < fabs(best_movement)) {
 					move = true;
 					best_movement = movement;
 				}
@@ -607,17 +629,16 @@ static double get_active_position(struct sway_workspace *workspace,
 		double y1 = workspace->y + scale * gaps;
 		for (int c = active_idx; c < children->length; ++c) {
 			struct sway_container *con = children->items[c];
-			y1 += scale * (con->current.height + gaps);
+			y1 += scale * (con->pending.height + gaps);
 			if (y1 <= workspace_end) {
 				c_r = c;
 				// Test from c_r to the beginning
 				double movement = DBL_MAX;
 				double cy0 = workspace->y + workspace->height;
 				bool space = true;
-				bool fits = false;
 				for (int i = c_r; i >= 0; i--) {
 					struct sway_container *con = children->items[i];
-					cy0 -= scale * (con->current.height + 2.0 * gaps);
+					cy0 -= scale * (con->pending.height + 2.0 * gaps);
 					if (i == active_idx) {
 						movement = (cy0 + scale * gaps) - a_y;
 					}
@@ -627,11 +648,8 @@ static double get_active_position(struct sway_workspace *workspace,
 							break;
 						}
 					}
-					if (c_r == children->length - 1 && i == 0) {
-						fits = true;
-					}
 				}
-				if ((!space || fits) &&	fabs(movement) < fabs(best_movement)) {
+				if (!space && fabs(movement) < fabs(best_movement)) {
 					move = true;
 					best_movement = movement;
 				}
@@ -663,51 +681,81 @@ static double compute_active_offset(struct sway_workspace *workspace,
 	if (layout == L_HORIZ) {
 		bool center = layout_modifiers_get_center_horizontal(workspace);
 		if (center) {
-			return workspace->x + 0.5 * (width - scale * active->current.width);
+			return workspace->x + 0.5 * (width - scale * active->pending.width);
 		}
-		// Center row if space available
-        double lwidth = 0, rwidth = 0;
-        for (int i = 0; i < active_idx; ++i) {
-			struct sway_container *con = children->items[i];
-            lwidth += scale * (con->current.width + 2 * gaps);
-        }
-		lwidth = round(lwidth);
-        for (int i = active_idx; i < children->length; ++i) {
-			struct sway_container *con = children->items[i];
-            rwidth += scale * (con->current.width + 2 * gaps);
-        }
-		rwidth = round(rwidth);
-        double twidth = lwidth + rwidth;
-        if (twidth <= width + 1) {
-			if (config->center_horizontal_if_fits) {
-	            double start = 0.5 * (width - twidth);
-		        return workspace->x + start + lwidth + scale * gaps;
+		enum sway_layout_align_policy policy = layout_modifiers_get_align_horiz_policy(workspace);
+		if (policy == ALIGN_POLICY_IF_FIT ||
+				(policy == ALIGN_POLICY_INITIAL && children->length == 1 &&
+						active->current.width == 0)) {
+			double lwidth = 0, rwidth = 0;
+			for (int i = 0; i < active_idx; ++i) {
+				struct sway_container *con = children->items[i];
+				lwidth += scale * (con->pending.width + 2 * gaps);
 			}
-        }
+			lwidth = round(lwidth);
+			for (int i = active_idx; i < children->length; ++i) {
+				struct sway_container *con = children->items[i];
+				rwidth += scale * (con->pending.width + 2 * gaps);
+			}
+			rwidth = round(rwidth);
+			double twidth = lwidth + rwidth;
+			if (twidth <= width + 1) {
+				double start = 0;
+				enum sway_layout_align_horiz align = layout_modifiers_get_align_horiz(workspace);
+				bool do_align = true;
+				if (align == ALIGN_HORIZ_CENTER) {
+					if (config->center_horizontal_if_fits) {
+						start = 0.5 * (width - twidth);
+					} else {
+						do_align = false;
+					}
+				} else if (align == ALIGN_HORIZ_RIGHT) {
+					start = width - twidth;
+				}
+				if (do_align) {
+					return workspace->x + start + lwidth + scale * gaps;
+				}
+			}
+		}
 	} else {
 		bool center = layout_modifiers_get_center_vertical(workspace);
 		if (center) {
 			return workspace->y + 0.5 * (height - scale * active->pending.height);
 		}
-		// Center row if space available
-        double lheight = 0, rheight = 0;
-        for (int i = 0; i < active_idx; ++i) {
-			struct sway_container *con = children->items[i];
-            lheight += scale * (con->current.height + 2 * gaps);
-        }
-		lheight = round(lheight);
-        for (int i = active_idx; i < children->length; ++i) {
-			struct sway_container *con = children->items[i];
-            rheight += scale * (con->current.height + 2 * gaps);
-        }
-		rheight = round(rheight);
-        double theight = lheight + rheight;
-        if (theight <= height + 1) {
-			if (config->center_vertical_if_fits) {
-	            double start = 0.5 * (height - theight);
-		        return workspace->y + start + lheight + scale * gaps;
+		enum sway_layout_align_policy policy = layout_modifiers_get_align_vert_policy(workspace);
+		if (policy == ALIGN_POLICY_IF_FIT ||
+				(policy == ALIGN_POLICY_INITIAL && children->length == 1 &&
+						active->current.height == 0)) {
+			double lheight = 0, rheight = 0;
+			for (int i = 0; i < active_idx; ++i) {
+				struct sway_container *con = children->items[i];
+				lheight += scale * (con->pending.height + 2 * gaps);
 			}
-        }
+			lheight = round(lheight);
+			for (int i = active_idx; i < children->length; ++i) {
+				struct sway_container *con = children->items[i];
+				rheight += scale * (con->pending.height + 2 * gaps);
+			}
+			rheight = round(rheight);
+			double theight = lheight + rheight;
+			if (theight <= height + 1) {
+				double start = 0;
+				enum sway_layout_align_vert align = layout_modifiers_get_align_vert(workspace);
+				bool do_align = true;
+				if (align == ALIGN_VERT_MIDDLE) {
+					if (config->center_vertical_if_fits) {
+						start = 0.5 * (height - theight);
+					} else {
+						do_align = false;
+					}
+				} else if (align == ALIGN_VERT_BOTTOM) {
+					start = height - theight;
+				}
+				if (do_align) {
+					return workspace->y + start + lheight + scale * gaps;
+				}
+			}
+		}
 	}
 	if (pin) {
 		return get_active_position_pin(workspace, layout, children, active_idx, gaps, scale, pin);
@@ -1764,7 +1812,7 @@ static void animate_children(struct sway_workspace *workspace,
 			child->animation.yt = child->animation.y0;
 			animation_set_animation_enabled(false);
 			// 1.0 to account for rounding errors when the workspace is scaled
-			const double movement = fabs(off -child->animation.y0);
+			const double movement = fabs(off - child->animation.y0);
 			if (movement > 1.0) {
 				child->animation.yt += linear_scale(0.0, off - child->animation.y0, x);
 				animation_set_animation_enabled(true);
@@ -1776,7 +1824,8 @@ static void animate_children(struct sway_workspace *workspace,
 					animation_set_animation_enabled(true);
 				}
 			}
-			wlr_scene_node_set_position(&child->scene_tree->node, xt, child->animation.yt - workspace->y);
+			wlr_scene_node_set_position(
+					&child->scene_tree->node, xt, child->animation.yt - workspace->y);
 			child->current.y = off;
 			child->pending.y = off;
 			if (parent) {
@@ -1797,7 +1846,7 @@ static void animate_children(struct sway_workspace *workspace,
 			child->animation.wt = fmax(1, linear_scale(child->animation.w0, child->animation.w1, t));
 			child->animation.xt = child->animation.x0;
 			animation_set_animation_enabled(false);
-			const double movement = fabs(off -child->animation.x0);
+			const double movement = fabs(off - child->animation.x0);
 			if (movement > 1.0) {
 				child->animation.xt += linear_scale(0.0, off - child->animation.x0, x);
 				animation_set_animation_enabled(true);
@@ -1810,7 +1859,8 @@ static void animate_children(struct sway_workspace *workspace,
 				}
 			}
 			wlr_scene_node_set_enabled(&child->decoration.tree->node, true);
-			wlr_scene_node_set_position(&child->scene_tree->node, child->animation.xt - workspace->x, yt);
+			wlr_scene_node_set_position(
+					&child->scene_tree->node, child->animation.xt - workspace->x, yt);
 			// Update child for next iteration. Transactions don't re-arrange
 			// the layout (arrange.c:apply_xxx()), so we need to set it here,
 			// otherwise the next call will have the positions wrong and the

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -1542,6 +1542,33 @@ json_object *ipc_json_describe_scroller(struct sway_workspace *workspace) {
 	json_object_object_add(object, "center_horizontal", json_object_new_boolean(center_horizontal));
 	bool center_vertical = layout_modifiers_get_center_vertical(workspace);
 	json_object_object_add(object, "center_vertical", json_object_new_boolean(center_vertical));
+
+	enum sway_layout_align_horiz align_horiz = layout_modifiers_get_align_horiz(workspace);
+	const char *align_horiz_str = "center";
+	if (align_horiz == ALIGN_HORIZ_LEFT) {
+		align_horiz_str = "left";
+	} else if (align_horiz == ALIGN_HORIZ_RIGHT) {
+		align_horiz_str = "right";
+	}
+	json_object_object_add(object, "align_horiz", json_object_new_string(align_horiz_str));
+
+	enum sway_layout_align_vert align_vert = layout_modifiers_get_align_vert(workspace);
+	const char *align_vert_str = "middle";
+	if (align_vert == ALIGN_VERT_TOP) {
+		align_vert_str = "top";
+	} else if (align_vert == ALIGN_VERT_BOTTOM) {
+		align_vert_str = "bottom";
+	}
+	json_object_object_add(object, "align_vert", json_object_new_string(align_vert_str));
+
+	enum sway_layout_align_policy policy_horiz = layout_modifiers_get_align_horiz_policy(workspace);
+	json_object_object_add(object, "align_horiz_policy",
+			json_object_new_string(policy_horiz == ALIGN_POLICY_INITIAL ? "initial" : "if_fits"));
+
+	enum sway_layout_align_policy policy_vert = layout_modifiers_get_align_vert_policy(workspace);
+	json_object_object_add(object, "align_vert_policy",
+			json_object_new_string(policy_vert == ALIGN_POLICY_INITIAL ? "initial" : "if_fits"));
+
 	enum sway_layout_reorder reorder = layout_modifiers_get_reorder(workspace);
 	json_object_object_add(object, "reorder",
 		json_object_new_string(reorder == REORDER_AUTO ? "auto" : "lazy"));

--- a/sway/lua.c
+++ b/sway/lua.c
@@ -1144,6 +1144,42 @@ static int scroll_workspace_get_mode(lua_State *L) {
 	lua_pushboolean(L, layout_modifiers_get_center_vertical(workspace) ? 1 : 0);
 	lua_setfield(L, -2, "center_vertical");
 
+	enum sway_layout_align_horiz align_horiz = layout_modifiers_get_align_horiz(workspace);
+	switch (align_horiz) {
+	case ALIGN_HORIZ_LEFT:
+		lua_pushstring(L, "left");
+		break;
+	case ALIGN_HORIZ_CENTER:
+		lua_pushstring(L, "center");
+		break;
+	case ALIGN_HORIZ_RIGHT:
+		lua_pushstring(L, "right");
+		break;
+	}
+	lua_setfield(L, -2, "align_horiz");
+
+	enum sway_layout_align_vert align_vert = layout_modifiers_get_align_vert(workspace);
+	switch (align_vert) {
+	case ALIGN_VERT_TOP:
+		lua_pushstring(L, "top");
+		break;
+	case ALIGN_VERT_MIDDLE:
+		lua_pushstring(L, "middle");
+		break;
+	case ALIGN_VERT_BOTTOM:
+		lua_pushstring(L, "bottom");
+		break;
+	}
+	lua_setfield(L, -2, "align_vert");
+
+	enum sway_layout_align_policy policy_horiz = layout_modifiers_get_align_horiz_policy(workspace);
+	lua_pushstring(L, policy_horiz == ALIGN_POLICY_INITIAL ? "initial" : "if_fits");
+	lua_setfield(L, -2, "align_horiz_policy");
+
+	enum sway_layout_align_policy policy_vert = layout_modifiers_get_align_vert_policy(workspace);
+	lua_pushstring(L, policy_vert == ALIGN_POLICY_INITIAL ? "initial" : "if_fits");
+	lua_setfield(L, -2, "align_vert_policy");
+
 	return 1;
 }
 
@@ -1202,6 +1238,50 @@ static int scroll_workspace_set_mode(lua_State *L) {
 
 	if (lua_getfield(L, 2, "center_vertical") == LUA_TBOOLEAN) {
 		layout_modifiers_set_center_vertical(workspace, lua_toboolean(L, 3));
+	}
+	lua_pop(L, 1);
+
+	if (lua_getfield(L, 2, "align_horiz") == LUA_TSTRING) {
+		const char *val = lua_tostring(L, 3);
+		if (strcmp(val, "left") == 0) {
+			layout_modifiers_set_align_horiz(workspace, ALIGN_HORIZ_LEFT);
+		} else if (strcmp(val, "center") == 0) {
+			layout_modifiers_set_align_horiz(workspace, ALIGN_HORIZ_CENTER);
+		} else if (strcmp(val, "right") == 0) {
+			layout_modifiers_set_align_horiz(workspace, ALIGN_HORIZ_RIGHT);
+		}
+	}
+	lua_pop(L, 1);
+
+	if (lua_getfield(L, 2, "align_vert") == LUA_TSTRING) {
+		const char *val = lua_tostring(L, 3);
+		if (strcmp(val, "top") == 0) {
+			layout_modifiers_set_align_vert(workspace, ALIGN_VERT_TOP);
+		} else if (strcmp(val, "middle") == 0) {
+			layout_modifiers_set_align_vert(workspace, ALIGN_VERT_MIDDLE);
+		} else if (strcmp(val, "bottom") == 0) {
+			layout_modifiers_set_align_vert(workspace, ALIGN_VERT_BOTTOM);
+		}
+	}
+	lua_pop(L, 1);
+
+	if (lua_getfield(L, 2, "align_horiz_policy") == LUA_TSTRING) {
+		const char *val = lua_tostring(L, 3);
+		if (strcmp(val, "initial") == 0) {
+			layout_modifiers_set_align_horiz_policy(workspace, ALIGN_POLICY_INITIAL);
+		} else if (strcmp(val, "if_fits") == 0) {
+			layout_modifiers_set_align_horiz_policy(workspace, ALIGN_POLICY_IF_FIT);
+		}
+	}
+	lua_pop(L, 1);
+
+	if (lua_getfield(L, 2, "align_vert_policy") == LUA_TSTRING) {
+		const char *val = lua_tostring(L, 3);
+		if (strcmp(val, "initial") == 0) {
+			layout_modifiers_set_align_vert_policy(workspace, ALIGN_POLICY_INITIAL);
+		} else if (strcmp(val, "if_fits") == 0) {
+			layout_modifiers_set_align_vert_policy(workspace, ALIGN_POLICY_IF_FIT);
+		}
 	}
 	lua_pop(L, 1);
 

--- a/sway/scroll.5.scd
+++ b/sway/scroll.5.scd
@@ -392,12 +392,12 @@ The following commands may only be used in the configuration file.
 The following commands cannot be used directly in the configuration file.
 They are expected to be used with *bindsym* or at runtime through *scrollmsg*(1).
 
-*align* <left|right|center|up|down|middle|reset>
+*align* <left|right|center|top|bottom|middle|reset>
 	Columns are generally aligned in automatic mode, always making the active
 	one visible, and trying to make at least the previously focused one visible
 	too if it fits the viewport, if not, the one adjacent on the other side.
 	However, you can always align any column to the center, left or right
-	of the monitor (in horizontal mode), or up (top), down (bottom) or to
+	of the monitor (in horizontal mode), or top (up), bottom (down) or to
 	the center in vertical mode. For example center a column for easier
 	reading, regardless of what happens to the other columns. If you want to
 	go back to automatic mode, you need to use the _set_mode_ modifier
@@ -879,7 +879,11 @@ set|plus|minus|toggle <amount>
 
 *set_mode* [<h|v|t> <after|before|end|beg> <focus|nofocus>
 <center_horiz|nocenter_horiz> <center_vert|nocenter_vert>
-<reorder_auto|noreorder_auto>]
+<reorder_auto|noreorder_auto>
+<align_horiz_initial|align_horiz_if_fits>
+<align_vert_initial|align_vert_if_fits>
+<align_horiz_left|align_horiz_center|align_horiz_right>
+<align_vert_top|align_vert_middle|align_vert_bottom>]
 	Modes and mode modifiers are per workspace.
 	At window creation time, scroll can apply several modifiers to the current
 	working mode (h/v). It supports extra arguments:
@@ -906,6 +910,14 @@ set|plus|minus|toggle <amount>
 
 	_center_vert/nocenter_vert_: It will keep the active window centered
 	(or not) in its column.
+
+	_align\_horiz\_<left|center|right>_: Set alignment for horizontal mode when all windows fit.
+
+	_align\_vert\_<top|middle|bottom>_: Set alignment for vertical mode when all windows fit.
+
+	_align\_horiz\_<initial|if\_fits>_: Set alignment policy for horizontal mode. _initial_ only aligns the first window and then preserves positions; _if\_fits_ always aligns when they fit.
+
+	_align\_vert\_<initial|if\_fits>_: Set alignment policy for vertical mode.
 
 	You can skip any number of parameters when calling the command, and
 	their order doesn't matter.

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -608,6 +608,14 @@ void layout_default_modifiers_set_default(struct sway_scroller_modifiers *modifi
 		modifiers->center_horizontal = false;
 		modifiers->center_vertical_set = true;
 		modifiers->center_vertical = false;
+		modifiers->align_horiz_set = true;
+		modifiers->align_horiz = ALIGN_HORIZ_CENTER;
+		modifiers->align_vert_set = true;
+		modifiers->align_vert = ALIGN_VERT_MIDDLE;
+		modifiers->align_horiz_policy_set = true;
+		modifiers->align_horiz_policy = ALIGN_POLICY_IF_FIT;
+		modifiers->align_vert_policy_set = true;
+		modifiers->align_vert_policy = ALIGN_POLICY_IF_FIT;
 	}
 }
 
@@ -645,6 +653,26 @@ static void modifiers_merge(struct sway_scroller_modifiers *dst, struct sway_scr
 		dst->center_vertical_set = true;
 		dst->set = true;
 	}
+	if (src->align_horiz_set) {
+		dst->align_horiz = src->align_horiz;
+		dst->align_horiz_set = true;
+		dst->set = true;
+	}
+	if (src->align_vert_set) {
+		dst->align_vert = src->align_vert;
+		dst->align_vert_set = true;
+		dst->set = true;
+	}
+	if (src->align_horiz_policy_set) {
+		dst->align_horiz_policy = src->align_horiz_policy;
+		dst->align_horiz_policy_set = true;
+		dst->set = true;
+	}
+	if (src->align_vert_policy_set) {
+		dst->align_vert_policy = src->align_vert_policy;
+		dst->align_vert_policy_set = true;
+		dst->set = true;
+	}
 }
 
 void layout_modifiers_init(struct sway_workspace *workspace) {
@@ -670,6 +698,10 @@ void layout_modifiers_init(struct sway_workspace *workspace) {
 	layout->modifiers.focus = modifiers.focus;
 	layout->modifiers.center_horizontal = modifiers.center_horizontal;
 	layout->modifiers.center_vertical = modifiers.center_vertical;
+	layout->modifiers.align_horiz = modifiers.align_horiz;
+	layout->modifiers.align_vert = modifiers.align_vert;
+	layout->modifiers.align_horiz_policy = modifiers.align_horiz_policy;
+	layout->modifiers.align_vert_policy = modifiers.align_vert_policy;
 }
 
 void layout_modifiers_set_reorder(struct sway_workspace *workspace, enum sway_layout_reorder reorder) {
@@ -735,6 +767,48 @@ bool layout_modifiers_get_center_vertical(struct sway_workspace *workspace) {
 	return workspace->layout.modifiers.center_vertical;
 }
 
+void layout_modifiers_set_align_horiz(
+		struct sway_workspace *workspace, enum sway_layout_align_horiz align) {
+	workspace->layout.modifiers.align_horiz = align;
+	ipc_event_scroller("align_horiz", workspace);
+}
+
+enum sway_layout_align_horiz layout_modifiers_get_align_horiz(struct sway_workspace *workspace) {
+	return workspace->layout.modifiers.align_horiz;
+}
+
+void layout_modifiers_set_align_vert(
+		struct sway_workspace *workspace, enum sway_layout_align_vert align) {
+	workspace->layout.modifiers.align_vert = align;
+	ipc_event_scroller("align_vert", workspace);
+}
+
+enum sway_layout_align_vert layout_modifiers_get_align_vert(struct sway_workspace *workspace) {
+	return workspace->layout.modifiers.align_vert;
+}
+
+void layout_modifiers_set_align_horiz_policy(
+		struct sway_workspace *workspace, enum sway_layout_align_policy policy) {
+	workspace->layout.modifiers.align_horiz_policy = policy;
+	ipc_event_scroller("align_horiz_policy", workspace);
+}
+
+enum sway_layout_align_policy layout_modifiers_get_align_horiz_policy(
+		struct sway_workspace *workspace) {
+	return workspace->layout.modifiers.align_horiz_policy;
+}
+
+void layout_modifiers_set_align_vert_policy(
+		struct sway_workspace *workspace, enum sway_layout_align_policy policy) {
+	workspace->layout.modifiers.align_vert_policy = policy;
+	ipc_event_scroller("align_vert_policy", workspace);
+}
+
+enum sway_layout_align_policy layout_modifiers_get_align_vert_policy(
+		struct sway_workspace *workspace) {
+	return workspace->layout.modifiers.align_vert_policy;
+}
+
 static int layout_insert_compute_index(list_t *list, void *active, enum sway_layout_insert pos) {
 	switch (pos) {
 	case INSERT_BEFORE:
@@ -761,19 +835,22 @@ static void position_new_container(struct sway_workspace *workspace,
 
 	int active_idx = list_find(children, active);
 	if (active_idx >= 0) {
+		double scale = layout_scale_enabled(workspace) ? layout_scale_get(workspace) : 1.0;
+		int gaps = workspace->gaps_inner;
 		if (layout_modifiers_get_mode(workspace) == L_HORIZ) {
 			if (container_idx < active_idx) {
 				double width = container->width_fraction * workspace->width;
-				container->pending.x = active->pending.x - width;
+				container->pending.x = active->pending.x - width - 2 * scale * gaps;
 			} else {
-				container->pending.x = active->pending.x + active->current.width;
+				container->pending.x = active->pending.x + active->current.width + 2 * scale * gaps;
 			}
 		} else {
 			if (container_idx < active_idx) {
 				double height = container->height_fraction * workspace->height;
-				container->pending.y = active->pending.y - height;
+				container->pending.y = active->pending.y - height - 2 * scale * gaps;
 			} else {
-				container->pending.y = active->pending.y + active->current.height;
+				container->pending.y =
+						active->pending.y + active->current.height + 2 * scale * gaps;
 			}
 		}
 	}
@@ -842,20 +919,48 @@ static void layout_workspace_add_view(struct sway_workspace *workspace, struct s
 	struct sway_container *parent = layout_wrap_into_container(view, mode);
 	float scale = layout_scale_enabled(workspace) ? layout_scale_get(workspace) : 1.0f;
 	// Set the container and view width/height
-	if (view->width_fraction <= 0.0) {
+	bool is_first = workspace->tiling->length == 0;
+	bool width_was_unset = view->width_fraction <= 0.0;
+	if (width_was_unset) {
 		view->width_fraction = layout_get_default_width(workspace);
 		// Start the animation from the center of the workspace
 		view->current.x = workspace->x + 0.5 * workspace->width;
-		view->pending.x = workspace->x + scale * workspace->gaps_inner;
 		parent->current.x = view->current.x;
+	}
+	if (width_was_unset || (is_first && layout_get_type(workspace) == L_HORIZ)) {
+		double start = 0;
+		if (is_first && layout_get_type(workspace) == L_HORIZ) {
+			enum sway_layout_align_horiz align = layout_modifiers_get_align_horiz(workspace);
+			double view_width = view->width_fraction * workspace->width;
+			if (align == ALIGN_HORIZ_CENTER) {
+				start = 0.5 * (workspace->width - view_width);
+			} else if (align == ALIGN_HORIZ_RIGHT) {
+				start = workspace->width - view_width;
+			}
+		}
+		view->pending.x = workspace->x + start + scale * workspace->gaps_inner;
 		parent->pending.x = view->pending.x;
 	}
 	parent->width_fraction = view->width_fraction;
-	if (view->height_fraction <= 0.0) {
+
+	bool height_was_unset = view->height_fraction <= 0.0;
+	if (height_was_unset) {
 		view->height_fraction = layout_get_default_height(workspace);
 		view->current.y = workspace->y + 0.5 * workspace->height;
-		view->pending.y = workspace->y + scale * workspace->gaps_inner;
 		parent->current.y = view->current.y;
+	}
+	if (height_was_unset || (is_first && layout_get_type(workspace) == L_VERT)) {
+		double start = 0;
+		if (is_first && layout_get_type(workspace) == L_VERT) {
+			enum sway_layout_align_vert align = layout_modifiers_get_align_vert(workspace);
+			double view_height = view->height_fraction * workspace->height;
+			if (align == ALIGN_VERT_MIDDLE) {
+				start = 0.5 * (workspace->height - view_height);
+			} else if (align == ALIGN_VERT_BOTTOM) {
+				start = workspace->height - view_height;
+			}
+		}
+		view->pending.y = workspace->y + start + scale * workspace->gaps_inner;
 		parent->pending.y = view->pending.y;
 	}
 	parent->height_fraction = view->height_fraction;

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -1,0 +1,462 @@
+from typing import Any, Dict, Optional
+from conftest import ScrollInstance
+import pytest
+from test_utils import wait_for_client_map, wayland_client
+
+
+def find_node(
+    node: Dict[str, Any], type_name: str, name: Optional[str] = None
+) -> Optional[Dict[str, Any]]:
+    if node.get("type") == type_name and (name is None or node.get("name") == name):
+        return node
+    for child in node.get("nodes", []):
+        n = find_node(child, type_name, name)
+        if n:
+            return n
+    for child in node.get("floating_nodes", []):
+        n = find_node(child, type_name, name)
+        if n:
+            return n
+    return None
+
+
+def get_workspace_rect(inst: ScrollInstance, name: str = "1") -> Dict[str, int]:
+    tree = inst.get_tree()
+    ws = find_node(tree, "workspace", name)
+    assert ws is not None
+    return ws["rect"]
+
+
+def get_container_geometry(inst: ScrollInstance, con_id: int) -> Dict[str, float]:
+    geom = inst.execute_lua(f"return scroll.container_get_geometry({con_id})")
+    assert geom is not None
+    return geom
+
+
+def test_default_alignment(scroll_compositor: ScrollInstance) -> None:
+    inst = scroll_compositor
+    ws_rect = get_workspace_rect(inst)
+
+    with wayland_client(inst, "client1"):
+        v1 = wait_for_client_map(inst, "client1")
+        c1 = inst.execute_lua(f"return scroll.view_get_container({v1})")
+        inst.wait_for_idle()
+
+        geom1 = get_container_geometry(inst, c1)
+        # By default, a single window should be centered.
+        # Expected x: ws_x + 0.5 * (ws_width - con_width)
+        expected_x = ws_rect["x"] + 0.5 * (ws_rect["width"] - geom1["width"])
+        assert abs(geom1["x"] - expected_x) < 1.0
+
+
+def test_horizontal_alignment_left(scroll_compositor: ScrollInstance) -> None:
+    inst = scroll_compositor
+    ws_rect = get_workspace_rect(inst)
+
+    inst.cmd("set_mode align_horiz_left")
+
+    with wayland_client(inst, "client1"):
+        v1 = wait_for_client_map(inst, "client1")
+        c1 = inst.execute_lua(f"return scroll.view_get_container({v1})")
+        inst.wait_for_idle()
+
+        geom1 = get_container_geometry(inst, c1)
+        # Left aligned: x should be ws_x + gaps
+        assert geom1["x"] < ws_rect["x"] + 0.1 * ws_rect["width"]
+
+
+@pytest.fixture(scope="function")
+def no_gaps_compositor(
+    scroll_compositor: ScrollInstance,
+) -> ScrollInstance:
+    scroll_compositor.cmd("gaps inner 0")
+    scroll_compositor.cmd("gaps outer 0")
+    scroll_compositor.cmd("output * layout_default_height 0.5")
+    scroll_compositor.wait_for_idle()
+    return scroll_compositor
+
+
+def test_horizontal_alignment_values(
+    no_gaps_compositor: ScrollInstance,
+) -> None:
+    inst = no_gaps_compositor
+    try:
+        ws_rect = get_workspace_rect(inst)
+
+        with wayland_client(inst, "client1"):
+            v1 = wait_for_client_map(inst, "client1")
+            c1 = inst.execute_lua(f"return scroll.view_get_container({v1})")
+            inst.wait_for_idle()
+            geom_center = get_container_geometry(inst, c1)
+            expected_center_x = ws_rect["x"] + 0.5 * (
+                ws_rect["width"] - geom_center["width"]
+            )
+            assert abs(geom_center["x"] - expected_center_x) < 1.0
+
+            # Change to left
+            inst.cmd("set_mode align_horiz_left")
+            inst.wait_for_idle()
+            geom_left = get_container_geometry(inst, c1)
+            assert abs(geom_left["x"] - ws_rect["x"]) < 1.0
+
+            # Change to right
+            inst.cmd("set_mode align_horiz_right")
+            inst.wait_for_idle()
+            geom_right = get_container_geometry(inst, c1)
+            expected_right_x = ws_rect["x"] + ws_rect["width"] - geom_right["width"]
+            assert abs(geom_right["x"] - expected_right_x) < 1.0
+    except AssertionError as e:
+        print("Compositor log:")
+        print(inst.read_log())
+        raise e
+
+
+def test_horizontal_policy_initial(no_gaps_compositor: ScrollInstance) -> None:
+    inst = no_gaps_compositor
+    ws_rect = get_workspace_rect(inst)
+
+    # Set policy to initial, align left
+    inst.cmd("set_mode align_horiz_left align_horiz_initial")
+
+    with wayland_client(inst, "client1") as c1_client:
+        v1 = wait_for_client_map(inst, "client1")
+        c1 = inst.execute_lua(f"return scroll.view_get_container({v1})")
+        inst.wait_for_idle()
+
+        geom1 = get_container_geometry(inst, c1)
+        # First window should be left-aligned (x = 0)
+        assert abs(geom1["x"] - ws_rect["x"]) < 1.0
+
+        with wayland_client(inst, "client2"):
+            v2 = wait_for_client_map(inst, "client2")
+            c2 = inst.execute_lua(f"return scroll.view_get_container({v2})")
+            inst.wait_for_idle()
+
+            geom1_after = get_container_geometry(inst, c1)
+            geom2 = get_container_geometry(inst, c2)
+
+            assert geom2["x"] > geom1_after["x"]
+
+            geom2_before_close = geom2
+
+            c1_client.terminate()
+            c1_client.wait()
+            inst.wait_for_idle()
+
+            geom2_after_close = get_container_geometry(inst, c2)
+            assert abs(geom2_after_close["x"] - geom2_before_close["x"]) < 1.0
+            # Confirm it did NOT center (centered would be 320)
+            assert (
+                abs(
+                    geom2_after_close["x"]
+                    - (
+                        ws_rect["x"]
+                        + 0.5 * (ws_rect["width"] - geom2_after_close["width"])
+                    )
+                )
+                > 10.0
+            )
+
+
+def test_vertical_alignment_values(no_gaps_compositor: ScrollInstance) -> None:
+    inst = no_gaps_compositor
+    ws_rect = get_workspace_rect(inst)
+
+    # Change to vertical mode
+    inst.cmd("set_mode v")
+    inst.wait_for_idle()
+
+    with wayland_client(inst, "client1"):
+        v1 = wait_for_client_map(inst, "client1")
+        c1 = inst.execute_lua(f"return scroll.view_get_container({v1})")
+        inst.wait_for_idle()
+        geom_middle = get_container_geometry(inst, c1)
+        expected_middle_y = ws_rect["y"] + 0.5 * (
+            ws_rect["height"] - geom_middle["height"]
+        )
+        assert abs(geom_middle["y"] - expected_middle_y) < 1.0
+
+        # Change to top
+        inst.cmd("set_mode align_vert_top")
+        inst.wait_for_idle()
+        geom_top = get_container_geometry(inst, c1)
+        assert abs(geom_top["y"] - ws_rect["y"]) < 1.0
+
+        # Change to bottom
+        inst.cmd("set_mode align_vert_bottom")
+        inst.wait_for_idle()
+        geom_bottom = get_container_geometry(inst, c1)
+        expected_bottom_y = ws_rect["y"] + ws_rect["height"] - geom_bottom["height"]
+        assert abs(geom_bottom["y"] - expected_bottom_y) < 1.0
+
+
+def test_vertical_policy_initial(no_gaps_compositor: ScrollInstance) -> None:
+    inst = no_gaps_compositor
+    ws_rect = get_workspace_rect(inst)
+
+    # Change to vertical mode, set policy to initial, align top
+    inst.cmd("set_mode v align_vert_top align_vert_initial")
+    inst.wait_for_idle()
+
+    with wayland_client(inst, "client1") as c1_client:
+        v1 = wait_for_client_map(inst, "client1")
+        c1 = inst.execute_lua(f"return scroll.view_get_container({v1})")
+        inst.wait_for_idle()
+
+        geom1 = get_container_geometry(inst, c1)
+        assert abs(geom1["y"] - ws_rect["y"]) < 1.0
+
+        with wayland_client(inst, "client2"):
+            v2 = wait_for_client_map(inst, "client2")
+            c2 = inst.execute_lua(f"return scroll.view_get_container({v2})")
+            inst.wait_for_idle()
+
+            geom1_after = get_container_geometry(inst, c1)
+            geom2 = get_container_geometry(inst, c2)
+
+            assert geom2["y"] > geom1_after["y"]
+
+            geom2_before_close = geom2
+
+            c1_client.terminate()
+            c1_client.wait()
+            inst.wait_for_idle()
+
+            geom2_after_close = get_container_geometry(inst, c2)
+            assert abs(geom2_after_close["y"] - geom2_before_close["y"]) < 1.0
+            # Confirm it did NOT center (middle)
+            assert (
+                abs(
+                    geom2_after_close["y"]
+                    - (
+                        ws_rect["y"]
+                        + 0.5 * (ws_rect["height"] - geom2_after_close["height"])
+                    )
+                )
+                > 10.0
+            )
+
+
+def test_lua_api(scroll_compositor: ScrollInstance) -> None:
+    inst = scroll_compositor
+    ws_id = inst.execute_lua("return scroll.focused_workspace()")
+
+    # Get default mode
+    mode = inst.execute_lua(f"return scroll.workspace_get_mode({ws_id})")
+    assert mode["align_horiz"] == "center"
+    assert mode["align_vert"] == "middle"
+    assert mode["align_horiz_policy"] == "if_fits"
+    assert mode["align_vert_policy"] == "if_fits"
+
+    # Set via Lua
+    inst.execute_lua(f"""
+        scroll.workspace_set_mode({ws_id}, {{
+            align_horiz = "left",
+            align_vert = "top",
+            align_horiz_policy = "initial",
+            align_vert_policy = "initial"
+        }})
+    """)
+
+    mode = inst.execute_lua(f"return scroll.workspace_get_mode({ws_id})")
+    assert mode["align_horiz"] == "left"
+    assert mode["align_vert"] == "top"
+    assert mode["align_horiz_policy"] == "initial"
+    assert mode["align_vert_policy"] == "initial"
+
+
+def test_vertical_alignment_in_column(
+    no_gaps_compositor: ScrollInstance,
+) -> None:
+    inst = no_gaps_compositor
+    try:
+        ws_rect = get_workspace_rect(inst)
+
+        # Set default height to 0.3 to make sure they fit when stacked
+        res = inst.cmd("output * layout_default_height 0.3")
+        assert res[0]["success"], f"Failed to set layout_default_height: {res}"
+
+        with wayland_client(inst, "client1"):
+            v1 = wait_for_client_map(inst, "client1")
+            c1 = inst.execute_lua(f"return scroll.view_get_container({v1})")
+            inst.wait_for_idle()
+            inst.cmd("set_mode v")
+            inst.wait_for_idle()
+
+            with wayland_client(inst, "client2"):
+                v2 = wait_for_client_map(inst, "client2")
+                c2 = inst.execute_lua(f"return scroll.view_get_container({v2})")
+                inst.wait_for_idle()
+                # They should both be in the same column.
+                # Let's verify they share x.
+                fraction1 = inst.execute_lua(
+                    f"return scroll.container_get_height_fraction({c1})"
+                )
+                fraction2 = inst.execute_lua(
+                    f"return scroll.container_get_height_fraction({c2})"
+                )
+                print(f"Fractions: {fraction1}, {fraction2}")
+                geom1 = get_container_geometry(inst, c1)
+                geom2 = get_container_geometry(inst, c2)
+                assert abs(geom1["x"] - geom2["x"]) < 1.0
+
+                # Total height of children: geom1["height"] + geom2["height"]
+                # They both have height_fraction 0.3.
+                h1 = 0.3 * ws_rect["height"]
+                h2 = 0.3 * ws_rect["height"]
+                total_h = h1 + h2
+
+                # By default, align_vert is 'middle'.
+                # So the column should be centered in workspace.
+                expected_y1 = ws_rect["y"] + 0.5 * (ws_rect["height"] - total_h)
+                expected_y2 = expected_y1 + h1
+                assert abs(geom1["y"] - expected_y1) < 1.0
+                assert abs(geom2["y"] - expected_y2) < 1.0
+
+                # Change align_vert to top
+                inst.cmd("set_mode align_vert_top")
+                inst.wait_for_idle()
+                geom1_top = get_container_geometry(inst, c1)
+                geom2_top = get_container_geometry(inst, c2)
+                # Should be at top: geom1 y = ws_y, geom2 y = ws_y + h1
+                assert abs(geom1_top["y"] - ws_rect["y"]) < 1.0
+                assert abs(geom2_top["y"] - (ws_rect["y"] + h1)) < 1.0
+
+                # Change align_vert to bottom
+                inst.cmd("set_mode align_vert_bottom")
+                inst.wait_for_idle()
+                geom1_bottom = get_container_geometry(inst, c1)
+                geom2_bottom = get_container_geometry(inst, c2)
+                # Should be at bottom: geom1 y = ws_y + ws_height - total_h, geom2 y = geom1_y + h1
+                expected_bottom_y1 = ws_rect["y"] + ws_rect["height"] - total_h
+                expected_bottom_y2 = expected_bottom_y1 + h1
+                assert abs(geom1_bottom["y"] - expected_bottom_y1) < 1.0
+                assert abs(geom2_bottom["y"] - expected_bottom_y2) < 1.0
+    except AssertionError as e:
+        print("Compositor log:")
+        print(inst.read_log())
+        raise e
+
+
+def test_shifting_bug(no_gaps_compositor: ScrollInstance) -> None:
+    inst = no_gaps_compositor
+    try:
+        ws_rect = get_workspace_rect(inst)
+
+        # Set align_horiz to left and policy to initial, and enable gaps
+        inst.cmd("set_mode align_horiz_left align_horiz_initial")
+        inst.cmd("output * layout_default_width 0.3")
+        inst.cmd("gaps inner all set 10")
+        inst.wait_for_idle()
+
+        gaps = 10
+
+        with wayland_client(inst, "client1"):
+            v1 = wait_for_client_map(inst, "client1")
+            c1 = inst.execute_lua(f"return scroll.view_get_container({v1})")
+            inst.wait_for_idle()
+
+            geom1 = get_container_geometry(inst, c1)
+            print(f"DEBUG: W1 initial: {geom1}")
+            # W1 should be at left edge + gaps
+            assert abs(geom1["x"] - (ws_rect["x"] + gaps)) < 1.0
+
+            with wayland_client(inst, "client2") as c2_client:
+                v2 = wait_for_client_map(inst, "client2")
+                c2 = inst.execute_lua(f"return scroll.view_get_container({v2})")
+                inst.wait_for_idle()
+
+                geom1_after_open = get_container_geometry(inst, c1)
+                geom2 = get_container_geometry(inst, c2)
+                print(f"DEBUG: W1 after open W2: {geom1_after_open}, W2: {geom2}")
+                # W1 should STILL be at left edge + gaps
+                assert abs(geom1_after_open["x"] - (ws_rect["x"] + gaps)) < 1.0, (
+                    f"W1 shifted to {geom1_after_open['x']} after opening W2"
+                )
+
+                # Close W2
+                c2_client.terminate()
+                c2_client.wait()
+                inst.wait_for_idle()
+
+                geom1_after_close = get_container_geometry(inst, c1)
+                print(f"DEBUG: W1 after close W2: {geom1_after_close}")
+                # W1 should STILL be at left edge + gaps
+                assert abs(geom1_after_close["x"] - (ws_rect["x"] + gaps)) < 1.0, (
+                    f"W1 shifted to {geom1_after_close['x']} after closing W2"
+                )
+
+                # Open W3
+                with wayland_client(inst, "client3"):
+                    v3 = wait_for_client_map(inst, "client3")
+                    c3 = inst.execute_lua(f"return scroll.view_get_container({v3})")
+                    inst.wait_for_idle()
+
+                    geom1_after_open3 = get_container_geometry(inst, c1)
+                    geom3 = get_container_geometry(inst, c3)
+                    print(f"DEBUG: W1 after open W3: {geom1_after_open3}, W3: {geom3}")
+                    # W1 should STILL be at left edge + gaps
+                    assert abs(geom1_after_open3["x"] - (ws_rect["x"] + gaps)) < 1.0, (
+                        f"W1 shifted to {geom1_after_open3['x']} after opening W3"
+                    )
+    except AssertionError as e:
+        print("Compositor log:")
+        print(inst.read_log())
+        raise e
+
+
+def test_initial_policy_offscreen(no_gaps_compositor: ScrollInstance) -> None:
+    inst = no_gaps_compositor
+    ws_rect = get_workspace_rect(inst)
+
+    # Set policy to initial, align left, default width 0.4 (so they fit with space)
+    inst.cmd("set_mode align_horiz_left align_horiz_initial")
+    inst.cmd("output * layout_default_width 0.4")
+    inst.wait_for_idle()
+
+    with wayland_client(inst, "client1") as c1_client:
+        v1 = wait_for_client_map(inst, "client1")
+        c1 = inst.execute_lua(f"return scroll.view_get_container({v1})")
+        inst.wait_for_idle()
+
+        geom1 = get_container_geometry(inst, c1)
+        assert abs(geom1["x"] - ws_rect["x"]) < 1.0
+
+        with wayland_client(inst, "client2"):
+            v2 = wait_for_client_map(inst, "client2")
+            c2 = inst.execute_lua(f"return scroll.view_get_container({v2})")
+            inst.wait_for_idle()
+
+            geom2 = get_container_geometry(inst, c2)
+            assert abs(geom2["x"] - (ws_rect["x"] + geom1["width"])) < 1.0
+
+            # Close W1, W2 should stay at its position (512)
+            c1_client.terminate()
+            c1_client.wait()
+            inst.wait_for_idle()
+
+            geom2_after = get_container_geometry(inst, c2)
+            assert abs(geom2_after["x"] - (ws_rect["x"] + geom1["width"])) < 1.0
+
+            # Open W3. It should be placed next to W2 (at 1024).
+            # W3 ends at 1024 + 512 = 1536 (offscreen).
+            # It should scroll to be visible.
+            # Min scroll to bring W3 into view is 256.
+            # So W3 should be at 1024 - 256 = 768.
+            # W2 should be at 512 - 256 = 256.
+            with wayland_client(inst, "client3"):
+                v3 = wait_for_client_map(inst, "client3")
+                c3 = inst.execute_lua(f"return scroll.view_get_container({v3})")
+                inst.wait_for_idle()
+
+                geom3 = get_container_geometry(inst, c3)
+                geom2_after_w3 = get_container_geometry(inst, c2)
+
+                # W3 should be visible
+                assert (
+                    geom3["x"] + geom3["width"] <= ws_rect["x"] + ws_rect["width"] + 1.0
+                )
+                # W3 should be at 768
+                assert abs(geom3["x"] - (ws_rect["x"] + 768)) < 1.0
+                # W2 should be at 256
+                assert abs(geom2_after_w3["x"] - (ws_rect["x"] + 256)) < 1.0


### PR DESCRIPTION
Introduce new configuration options to control window alignment on horizontally
and vertically scrolling workspaces when they fit within the viewport:

- `align_horiz` (left/center/right)
- `align_horiz_policy` (if-fit/initial)
- `align_vert` (top/middle/bottom)
- `align_vert_policy` (if-fit/initial)

The default behavior (recentering everything when it fits) is preserved
under the `if-fit` policy.

The `initial` policy aligns the first window according to the alignment option,
but preserves its position when subsequent windows are opened or closed. This
is implemented by only triggering alignment when the active container is new
(i.e., its current size is 0).

To ensure windows are not positioned offscreen when they would otherwise fit,
clamping logic is added to `get_active_position` to keep them fully within
viewport boundaries while minimizing movement. Layout calculations now use
target (pending) sizes instead of current sizes to ensure correct positioning.

These options are also:
- Exposed via the Lua API and IPC JSON.
- Documented in the README and man pages.
- Covered by integration tests in `tests/test_alignment.py`.