### PR TITLE
Fix z-order for pinned containers during animation

### DIFF
--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -1307,6 +1307,10 @@ static void arrange_workspace_tiling(struct sway_workspace *ws,
 			ws->current.focused_inactive_child, ws->layers.tiling,
 			ws->gaps_inner);
 	}
+	struct sway_container *pin = layout_pin_enabled(ws) ? layout_pin_get_container(ws) : NULL;
+	if (pin) {
+		wlr_scene_node_raise_to_top(&pin->scene_tree->node);
+	}
 }
 
 static void animate_workspace_tiling(struct sway_workspace *ws) {


### PR DESCRIPTION
- Raise the pinned container's scene node to the top of the tiling layer at the end of `animate_children`. This ensures that other containers animate behind the pinned window instead of sliding over it.