### PR TITLE
Add interactive test helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -2163,3 +2163,35 @@ events: `scroller`, `trails`, `lua`
 ### scrollnag
 
 `--edge center`, `--width`
+
+## Testing
+
+A pytest-based integration test suite is included in the `tests/` directory.
+
+To run the test suite directly:
+
+```sh
+pytest -v
+```
+
+This will automatically configure and build the project using Meson/Ninja in a local `build/` 
+directory, set up a headless compositor instance, and run the tests.
+
+### Interactive Testing
+
+You can run `scroll` interactively with AddressSanitizer (ASan) enabled and the default configuration by running:
+
+```sh
+./tests/interactive.sh
+```
+
+This script will:
+- Build `scroll` with ASan enabled (similar to automated tests).
+- Prepend the directories containing the built binaries (`scroll`, `scrollmsg`, `scrollbar`, `scrollnag`) to your `PATH` so they can be found by `scroll` and its children.
+- Run `scroll` using the default `config.in` configuration.
+
+You can override the configuration file by passing `-c` or `--config` arguments:
+
+```sh
+./tests/interactive.sh -c /path/to/custom/config
+```

--- a/tests/interactive.sh
+++ b/tests/interactive.sh
@@ -1,0 +1,57 @@
+#!/bin/sh -e
+
+# Find project root
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+PROJECT_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+
+cd "$PROJECT_ROOT"
+
+# Ensure we are in a nix develop shell or similar if needed
+if ! command -v meson >/dev/null 2>&1; then
+    echo "Error: meson not found." >&2
+    echo "Please run this script inside 'nix develop' or ensure development dependencies are installed." >&2
+    exit 1
+fi
+
+echo "Building scroll with ASan enabled..."
+if [ ! -d build ]; then
+    meson setup build -Dwerror=false -Db_sanitize=address
+else
+    meson configure build -Db_sanitize=address
+fi
+ninja -C build
+
+# Put built binaries in PATH
+BUILD_DIR="$PROJECT_ROOT/build"
+export PATH="$BUILD_DIR/sway:$BUILD_DIR/swaymsg:$BUILD_DIR/swaybar:$BUILD_DIR/swaynag:$PATH"
+
+DEFAULT_CONFIG="$PROJECT_ROOT/config.in"
+
+# Check if user provided a config file via -c or --config
+has_config=false
+for arg in "$@"; do
+    case "$arg" in
+        -c|--config)
+            has_config=true
+            break
+            ;;
+    esac
+done
+
+if [ "$has_config" = "false" ]; then
+    CONFIG="$DEFAULT_CONFIG"
+    if [ -n "${SCROLL_CONFIG:-}" ]; then
+        CONFIG="$SCROLL_CONFIG"
+    fi
+    echo "Using default config: $CONFIG"
+    # Prepend -c <config> to arguments
+    set -- -c "$CONFIG" "$@"
+fi
+
+# Enable leak detection but use suppressions for known system library leaks.
+export ASAN_OPTIONS="detect_leaks=1${ASAN_OPTIONS:+:$ASAN_OPTIONS}"
+export LSAN_OPTIONS="suppressions=$PROJECT_ROOT/tests/lsan.supp${LSAN_OPTIONS:+:$LSAN_OPTIONS}"
+
+echo "Starting scroll..."
+echo "PATH is set to: $PATH"
+exec scroll "$@"


### PR DESCRIPTION
This commit adds 'tests/interactive.sh' which builds scroll with ASan enabled and runs it interactively with the default config (or custom config) and proper PATH and LSan suppressions.

Also documents the usage in README.md.