### PR TITLE
ipc: expose surface_content_rect in get_tree

### DIFF
--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -591,6 +591,8 @@ static void ipc_json_describe_view(struct sway_container *c, json_object *object
 
 	struct wlr_box geometry = {0, 0, c->view->natural_width, c->view->natural_height};
 	json_object_object_add(object, "geometry", ipc_json_create_rect(&geometry));
+	json_object_object_add(
+			object, "surface_content_rect", ipc_json_create_rect(&c->view->geometry));
 
 	json_object_object_add(object, "max_render_time", json_object_new_int(c->view->max_render_time));
 

--- a/sway/scroll-ipc.7.scd
+++ b/sway/scroll-ipc.7.scd
@@ -361,6 +361,10 @@ node and will have the following properties:
 |- geometry
 :  object
 :  The natural geometry of the contents if it were to size itself
+|- surface_content_rect
+:  object
+:  (Only windows) The geometry of the view content relative to its surface.
+   This includes _x_, _y_, _width_, and _height_.
 |- urgent
 :  boolean
 :  Whether the node or any of its descendants has the urgent hint set. Note:

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -65,6 +65,13 @@ def test_static_geometry(scroll_compositor: ScrollInstance) -> None:
 
         target_node = find_node(tree, con_id)
         assert target_node is not None
+        assert "surface_content_rect" in target_node
+        view_geom = target_node["surface_content_rect"]
+        assert "x" in view_geom
+        assert "y" in view_geom
+        assert "width" in view_geom
+        assert "height" in view_geom
+
         rect = target_node["rect"]
         deco_rect = target_node.get("deco_rect", {"height": 0})
 


### PR DESCRIPTION
Expose the actual view geometry (as set by the client via xdg-shell set_window_geometry) in the IPC get_tree output as 'surface_content_rect'.

This is useful for clients using protocols like ext-image-copy-capture-v1 to capture foreign windows. Since the capture contains the full window surface (including Client-Side Decorations, shadows, etc.), the client needs to know the offset of the actual window content within the captured image. The surface_content_rect field exposes this offset (x, y) and size (width, height) relative to the surface.