### PR TITLE
Defer workspace switch animation scheduling to transaction commit

### DIFF
--- a/include/sway/tree/workspace.h
+++ b/include/sway/tree/workspace.h
@@ -116,6 +116,9 @@ struct sway_workspace *workspace_auto_back_and_forth(
 
 bool workspace_switch(struct sway_workspace *workspace);
 
+void animate_workspace_switch(
+		struct sway_output *output, struct sway_workspace *from, struct sway_workspace *to);
+
 struct sway_workspace *workspace_by_number(const char* name);
 
 struct sway_workspace *workspace_by_name(const char*);

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -2299,6 +2299,19 @@ static void _transaction_commit_dirty(bool server_request, bool delayed) {
 		return;
 	}
 
+	for (int i = 0; i < root->outputs->length; i++) {
+		struct sway_output *output = root->outputs->items[i];
+		struct sway_workspace *old_ws = output->current.active_workspace;
+		struct sway_workspace *new_ws = output_get_active_workspace(output);
+		if (old_ws && new_ws && old_ws != new_ws) {
+			if (!layout_overview_workspaces_enabled() && animation_enabled() &&
+					animation_path_enabled(ANIMATION_WORKSPACE_SWITCH) &&
+					!new_ws->node.destroying && new_ws->split.sibling != old_ws) {
+				animate_workspace_switch(output, old_ws, new_ws);
+			}
+		}
+	}
+
 	save_animation_variables();
 
 	transaction_commit_pending();

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -1016,8 +1016,8 @@ static bool workspace_switch_down(struct sway_output *output,
 	return f_idx < t_idx;
 }
 
-static void animate_workspace_switch(struct sway_output *output,
-		struct sway_workspace *from, struct sway_workspace *to) {
+void animate_workspace_switch(
+		struct sway_output *output, struct sway_workspace *from, struct sway_workspace *to) {
 	if (output->workspace_switching && !animation_animating()) {
 		sway_log(SWAY_ERROR, "Switching workspace twice in the same transaction");
 		return;
@@ -1025,11 +1025,8 @@ static void animate_workspace_switch(struct sway_output *output,
 	output->workspace_switching = true;
 	bool down = workspace_switch_down(output, from, to);
 
-	// Store the from workspace data here, because it may get deleted when
-	// calling animation_end() if it is empty. workspace_switch_callback_end
-	// calls transaction_commit_dirty(), which will destroy workspaces marked
-	// for deletion, and empty workspaces that are not active are marked for
-	// deletion.
+	// Store the from workspace data. If it was already destroying at the time of commit,
+	// we set it to NULL because it has no containers to animate.
 	struct workspace_switch_data *data = malloc(sizeof(struct workspace_switch_data));
 	const double from_y = from->y;
 	const int from_height = from->height;
@@ -1039,7 +1036,6 @@ static void animate_workspace_switch(struct sway_output *output,
 	data->from_containers = create_list();
 	data->to_containers = create_list();
 
-	animation_end();
 	animation_set_type(ANIMATION_WORKSPACE_SWITCH);
 
 	double min_y_to = to->y, max_y_to = to->y + to->height;
@@ -1112,18 +1108,7 @@ bool workspace_switch(struct sway_workspace *workspace) {
 	}
 	seat_set_focus(seat, next);
 
-	// old_ws may not have an output because it is being destroyed if empty
-	if (!layout_overview_workspaces_enabled() && old_ws != workspace && (
-		(old_ws->output && old_ws->output == workspace->output) ||
-		(old_ws->output && !workspace->output) ||
-		(!old_ws->output && workspace->output)) &&
-		workspace->split.sibling != old_ws &&
-		animation_enabled() && animation_path_enabled(ANIMATION_WORKSPACE_SWITCH)) {
-		struct sway_output *output = old_ws->output ? old_ws->output : workspace->output;
-		animate_workspace_switch(output, old_ws, workspace);
-	} else {
-		arrange_workspace(workspace);
-	}
+	arrange_workspace(workspace);
 
 	// Garbage collection of empty workspaces
 	root_for_each_workspace(workspace_consider_destroy_iter, NULL);


### PR DESCRIPTION
Eagerly scheduling workspace switch animations inside the `workspace_switch`
function (which runs during command execution) causes issues when multiple
switches are executed in the same transaction (e.g. `workspace 1; workspace 2`).
Both switches attempt to eagerly apply delta offsets to container coordinates,
corrupting the geometries.

To address this, we decouple the animation scheduling from the switch command:
1. We remove animation scheduling from `workspace_switch` and only perform
   `arrange_workspace` immediately.
2. In `_transaction_commit_dirty` (inside `sway/desktop/transaction.c`), we
   iterate over all outputs right before committing, compare the initial active
   workspace with the final focused workspace, and schedule a single animation
   for the net change.

This deferred scheduling resolves the re-entrancy bug completely.