### PR TITLE
Fix transaction reentrancy in execute_command

### DIFF
--- a/sway/commands.c
+++ b/sway/commands.c
@@ -293,6 +293,7 @@ list_t *execute_command(char *_exec, struct sway_seat *seat,
 	config->handler_context.seat = seat;
 
 	// Make all transactions belonging to this command be delayed
+	bool old_delay = server.delay_transaction;
 	server.delay_transaction = true;
 	do {
 		for (; isspace(*head); ++head) {}
@@ -395,7 +396,7 @@ list_t *execute_command(char *_exec, struct sway_seat *seat,
 		free_argv(argc, argv);
 	} while(head);
 cleanup:
-	server.delay_transaction = false;
+	server.delay_transaction = old_delay;
 	free(exec);
 	list_free(containers);
 	return res_list;

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -909,6 +909,7 @@ static void handle_set_hints(struct wl_listener *listener, void *data) {
 	}
 	if (view->allow_request_urgent) {
 		view_set_urgent(view, hints_urgency);
+		transaction_commit_dirty();
 	}
 }
 

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -561,6 +561,7 @@ void view_request_activate(struct sway_view *view, struct sway_seat *seat) {
 void view_request_urgent(struct sway_view *view) {
 	if (config->focus_on_window_activation != FOWA_NONE) {
 		view_set_urgent(view, true);
+		transaction_commit_dirty();
 	}
 }
 


### PR DESCRIPTION
Nested calls to execute_command (for example, when a Lua script
executed via a command runs scroll.command()) would prematurely
reset server.delay_transaction to false when the inner command
finished. This caused subsequent state changes in the outer command
to commit eagerly instead of being delayed.

Fix this by saving and restoring the server.delay_transaction flag
on the stack in execute_command, ensuring it remains true until the
outermost command finishes. This avoids sending unnecessary Wayland
configure messages to clients for intermediate layouts.

Also, ensure that transaction commits are triggered for urgency state
changes that occur outside of commands:
- X11 hints updates in handle_hints (sway/desktop/xwayland.c)
- Wayland activation requests falling back to urgency in
  view_request_urgent (sway/tree/view.c)

Finally, revert the previous workaround that added
transaction_commit_dirty() to scroll_command() in sway/lua.c, as it
is no longer necessary now that the reentrancy bug is fixed.