### PR TITLE
Ignore stale client commits on floating resize

### DIFF
--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -292,6 +292,20 @@ static const struct sway_view_impl view_impl = {
 	.destroy = destroy,
 };
 
+static bool is_commit_stale(struct sway_view *view, struct wlr_xdg_surface *xdg_surface) {
+	uint32_t latest_serial = 0;
+	if (xdg_surface->configure_idle != NULL) {
+		latest_serial = xdg_surface->scheduled_serial;
+	} else if (!wl_list_empty(&xdg_surface->configure_list)) {
+		struct wlr_xdg_surface_configure *configure =
+				wl_container_of(xdg_surface->configure_list.prev, configure, link);
+		latest_serial = configure->serial;
+	} else {
+		return false;
+	}
+	return xdg_surface->current.configure_serial < latest_serial;
+}
+
 static void handle_commit(struct wl_listener *listener, void *data) {
 	struct sway_xdg_shell_view *xdg_shell_view =
 		wl_container_of(listener, xdg_shell_view, commit);
@@ -341,20 +355,21 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 			new_geo->height != view->geometry.height ||
 			new_geo->x != view->geometry.x ||
 			new_geo->y != view->geometry.y;
-
 	if (new_size) {
 		// The client changed its surface size in this commit. For floating
 		// containers, we resize the container to match. For tiling containers,
 		// we only recenter the surface.
 		memcpy(&view->geometry, new_geo, sizeof(struct wlr_box));
 		if (container_is_floating(view->container)) {
-			view_update_size(view);
-			// Only set the toplevel size the current container actually has a size.
-			if (view->container->current.width) {
-				wlr_xdg_toplevel_set_size(view->wlr_xdg_toplevel, view->geometry.width,
-					view->geometry.height);
+			if (!is_commit_stale(view, xdg_surface)) {
+				view_update_size(view);
+				// Only set the toplevel size the current container actually has a size.
+				if (view->container->current.width) {
+					wlr_xdg_toplevel_set_size(
+							view->wlr_xdg_toplevel, view->geometry.width, view->geometry.height);
+				}
+				transaction_commit_dirty_client();
 			}
-			transaction_commit_dirty_client();
 		}
 
 		view_center_and_clip_surface(view);

--- a/tests/clients/wayland-client.c
+++ b/tests/clients/wayland-client.c
@@ -19,6 +19,7 @@ struct client_state {
 	struct xdg_toplevel *xdg_toplevel;
 	struct wl_buffer *buffer;
 	int width, height;
+	int buffer_width, buffer_height;
 	void *shm_data;
 };
 
@@ -51,6 +52,14 @@ static void xdg_surface_configure(void *data, struct xdg_surface *xdg_surface, u
 	struct client_state *state = data;
 	xdg_surface_ack_configure(xdg_surface, serial);
 
+	if (state->buffer &&
+			(state->buffer_width != state->width || state->buffer_height != state->height)) {
+		wl_buffer_destroy(state->buffer);
+		state->buffer = NULL;
+		munmap(state->shm_data, state->buffer_width * 4 * state->buffer_height);
+		state->shm_data = NULL;
+	}
+
 	if (!state->buffer) {
 		int stride = state->width * 4;
 		int size = stride * state->height;
@@ -78,6 +87,8 @@ static void xdg_surface_configure(void *data, struct xdg_surface *xdg_surface, u
 		for (int i = 0; i < state->width * state->height; ++i) {
 			pixels[i] = 0xFF0000FF; // Blue
 		}
+		state->buffer_width = state->width;
+		state->buffer_height = state->height;
 	}
 
 	wl_surface_attach(state->surface, state->buffer, 0, 0);
@@ -86,7 +97,14 @@ static void xdg_surface_configure(void *data, struct xdg_surface *xdg_surface, u
 }
 static const struct xdg_surface_listener xdg_surface_listener = { xdg_surface_configure };
 
-static void xdg_toplevel_configure(void *data, struct xdg_toplevel *xdg_toplevel, int32_t width, int32_t height, struct wl_array *states) {}
+static void xdg_toplevel_configure(void *data, struct xdg_toplevel *xdg_toplevel, int32_t width,
+		int32_t height, struct wl_array *states) {
+	struct client_state *state = data;
+	if (width > 0 && height > 0) {
+		state->width = width;
+		state->height = height;
+	}
+}
 static void xdg_toplevel_close(void *data, struct xdg_toplevel *xdg_toplevel) {
 	exit(0);
 }

--- a/tests/test_scratchpad_geometry.py
+++ b/tests/test_scratchpad_geometry.py
@@ -1,0 +1,42 @@
+from conftest import ScrollInstance
+from test_utils import wait_for_client_map, wayland_client
+
+
+def test_scratchpad_geometry_rules(scroll_compositor: ScrollInstance) -> None:
+    inst = scroll_compositor
+    title = "Scratchpad Test"
+
+    # Register for_window rule
+    res = inst.cmd(
+        f'for_window [title="{title}"] "move scratchpad, resize set 500 px 500 px, move position 100 100"'
+    )
+
+    assert res[0]["success"], f"for_window command failed: {res}"
+
+    try:
+        with wayland_client(inst, title):
+            view_id = wait_for_client_map(inst, title)
+            assert view_id is not None
+
+            con_id = inst.execute_lua(f"return scroll.view_get_container({view_id})")
+            assert con_id is not None
+
+            # Wait for any animation to settle (though scratchpad hidden windows might not animate)
+            inst.wait_for_idle()
+
+            geom = inst.execute_lua(f"return scroll.container_get_geometry({con_id})")
+            print("Scratchpad Geometry:", geom)
+
+            # Assert geometry
+            assert geom is not None
+            assert geom["width"] == 500
+            assert geom["height"] == 500
+            assert geom["x"] == 100
+            assert geom["y"] == 100
+
+            # Clean up
+            inst.execute_lua(f"scroll.view_close({view_id})")
+    except Exception:
+        print("Compositor log:")
+        print(inst.read_log())
+        raise

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -87,6 +87,7 @@ f:close()
 
 DEFAULT_CONFIG = "workspace 1\nxwayland force\nanimations enabled no\n"
 
+
 class ScrollInstance:
     proc: subprocess.Popen
     ipc: ScrollIPC
@@ -416,10 +417,37 @@ def wait_for_client_map(compositor: ScrollInstance, title: str) -> int:
     tries: int = 0
     while tries < 50:
         view_id = compositor.execute_lua(f"""
-            local view = scroll.focused_view()
-            if view and scroll.view_get_title(view) == "{title}" then
-                return view
+            local function find_view(title)
+                -- Check scratchpad
+                for _, con in ipairs(scroll.scratchpad_get_containers()) do
+                    for _, view in ipairs(scroll.container_get_views(con)) do
+                        if scroll.view_get_title(view) == title then
+                            return view
+                        end
+                    end
+                end
+                -- Check all outputs and workspaces
+                for _, output in ipairs(scroll.root_get_outputs()) do
+                    for _, ws in ipairs(scroll.output_get_workspaces(output)) do
+                        for _, con in ipairs(scroll.workspace_get_tiling(ws)) do
+                            for _, view in ipairs(scroll.container_get_views(con)) do
+                                if scroll.view_get_title(view) == title then
+                                    return view
+                                end
+                            end
+                        end
+                        for _, con in ipairs(scroll.workspace_get_floating(ws)) do
+                            for _, view in ipairs(scroll.container_get_views(con)) do
+                                if scroll.view_get_title(view) == title then
+                                    return view
+                                end
+                            end
+                        end
+                    end
+                end
+                return nil
             end
+            return find_view("{title}")
         """)
         if view_id is not None:
             assert isinstance(view_id, int)


### PR DESCRIPTION
When a new view is mapped, criteria rules may configure its
geometry (e.g. `resize set`). This configuration sends a new
configure event to the client.

However, during the map event handling, we are still processing
the initial commit from the client. After the map event is
handled and the rule-configured geometry is applied via a
transaction, the compositor's commit handler (`handle_commit`)
continues.

For floating containers, `handle_commit` resizes the container to
match the client's committed buffer size. If it processes the
initial commit (which has the initial client size, not the
configured one), it overrides the configured geometry back to the
initial size.

To fix this, we introduce `is_commit_stale` helper which checks
if there is a pending or scheduled configure event with a newer
serial than the serial acknowledged by the current commit. If the
commit is stale, we ignore its size for resizing floating
containers, waiting instead for the client to acknowledge and
commit the newly configured size.

How to reproduce:
1. Register the for_window rule:
   swaymsg 'for_window [title="Scratchpad Test"] move scratchpad, resize set 500 500'
2. Start the client:
   foot -T "Scratchpad Test"
3. Query the scratchpad window geometry:
   swaymsg -t get_tree | jq '.. | select(.name? == "__i3_scratch") | .floating_nodes[] | select(.name == "Scratchpad Test") | .rect'

   On buggy versions, this will output the client's default size
   instead of the configured 500x500.

Additionally:
*   Make `wait_for_client_map` test utility robust by searching
    all workspaces and the scratchpad for the mapped view, instead
    of just checking the focused view. This allows it to be used
    for windows that are moved to the scratchpad (and thus
    hidden/unfocused) immediately upon mapping.
*   Update `wayland-client.c` to support dynamic resizing in tests.
*   Add integration test `tests/test_scratchpad_geometry.py` to
    verify the fix.