### PR TITLE
Add scroll.context_container Lua API

### DIFF
--- a/include/sway/lua.h
+++ b/include/sway/lua.h
@@ -33,6 +33,7 @@ struct sway_lua {
 	list_t *cbs_jump_end;
 	int command_data;
 	list_t *cbs_command_end;
+	struct sway_container *context_container;
 };
 
 int luaopen_scroll(lua_State *L);

--- a/scroll.lua
+++ b/scroll.lua
@@ -132,6 +132,14 @@ function scroll.focused_view() end
 function scroll.focused_container() end
 
 ---
+--- Returns the container ID of the execution context if the command/script
+--- was run via criteria (e.g. `[class="XTerm"] lua script.lua`), or nil if
+--- there is no context (run globally).
+---
+--- @return integer|nil
+function scroll.context_container() end
+
+---
 --- Returns the focused workspace ID or nil if none.
 ---
 --- @return integer|nil

--- a/sway/commands/lua.c
+++ b/sway/commands/lua.c
@@ -97,10 +97,18 @@ cleanup:
 		return res;
 	}
 
+	struct sway_container *old_context_container = config->lua.context_container;
+	if (config->handler_context.node_overridden) {
+		config->lua.context_container = config->handler_context.container;
+	} else {
+		config->lua.context_container = NULL;
+	}
+
 	int err = luaL_loadfile(config->lua.state, expanded_path);
 	if (err != LUA_OK) {
 		struct cmd_results *res = cmd_results_new(CMD_FAILURE, "Error %d loading lua script %s", err, expanded_path);
 		free(expanded_path);
+		config->lua.context_container = old_context_container;
 		return res;
 	}
 
@@ -129,9 +137,10 @@ cleanup:
 		}
 		goto finish;
 	}
-	res =  cmd_results_new(CMD_SUCCESS, NULL);
+	res = cmd_results_new(CMD_SUCCESS, NULL);
 
 finish:
+	config->lua.context_container = old_context_container;
 	free(expanded_path);
 	return res;
 }
@@ -140,6 +149,13 @@ struct cmd_results *cmd_lua_eval(int argc, char **argv) {
 	struct cmd_results *error = NULL;
 	if ((error = checkarg(argc, "lua_eval", EXPECTED_AT_LEAST, 2))) {
 		return error;
+	}
+
+	struct sway_container *old_context_container = config->lua.context_container;
+	if (config->handler_context.node_overridden) {
+		config->lua.context_container = config->handler_context.container;
+	} else {
+		config->lua.context_container = NULL;
 	}
 
 	struct cmd_results *res = NULL;
@@ -180,8 +196,9 @@ struct cmd_results *cmd_lua_eval(int argc, char **argv) {
 		}
 		goto cleanup;
 	}
-	res =  cmd_results_new(CMD_SUCCESS, NULL);
+	res = cmd_results_new(CMD_SUCCESS, NULL);
 
 cleanup:
+	config->lua.context_container = old_context_container;
 	return res;
 }

--- a/sway/lua.c
+++ b/sway/lua.c
@@ -560,6 +560,12 @@ static int scroll_focused_container(lua_State *L) {
 	return 1;
 }
 
+static int scroll_context_container(lua_State *L) {
+	struct sway_container *container = config->lua.context_container;
+	lua_push_node(L, container ? &container->node : NULL);
+	return 1;
+}
+
 static int scroll_focused_workspace(lua_State *L) {
 	struct sway_node *node = get_focused_node();
 	struct sway_workspace *workspace = NULL;
@@ -1938,6 +1944,7 @@ static luaL_Reg const scroll_lib[] = {
 	{ "node_get_type", scroll_node_get_type },
 	{ "focused_view", scroll_focused_view },
 	{ "focused_container", scroll_focused_container },
+	{ "context_container", scroll_context_container },
 	{ "focused_workspace", scroll_focused_workspace },
 	{ "urgent_view", scroll_urgent_view },
 	{ "view_mapped", scroll_view_mapped },

--- a/sway/scroll.5.scd
+++ b/sway/scroll.5.scd
@@ -2219,6 +2219,11 @@ local process_data = scroll.exec_process("kitty")
 *focused_container()*
 	Returns the focused container ID or nil if none
 
+*context_container()*
+	Returns the container ID of the execution context if the command/script
+	was run via criteria (e.g. `[class="XTerm"] lua script.lua`), or nil if
+	there is no context (run globally).
+
 *focused_workspace()*
 	Returns the focused workspace ID or nil if none
 

--- a/tests/scrollipc.py
+++ b/tests/scrollipc.py
@@ -11,6 +11,7 @@ IPC_COMMAND: int = 0
 IPC_GET_WORKSPACES: int = 1
 IPC_SUBSCRIBE: int = 2
 IPC_GET_VERSION: int = 7
+IPC_LUA_EVAL: int = 124
 
 
 class ScrollIPC:
@@ -68,3 +69,12 @@ class ScrollIPC:
         if reply_type != 4:
             raise ValueError(f"Unexpected reply type: {reply_type}")
         return json.loads(reply_payload)
+
+    def lua_eval(self, code: str) -> dict:
+        self._send(IPC_LUA_EVAL, code)
+        reply_type, reply_payload = self._recv()
+        if reply_type != IPC_LUA_EVAL:
+            raise ValueError(f"Unexpected reply type: {reply_type}")
+        result = json.loads(reply_payload)
+        assert isinstance(result, dict)
+        return result

--- a/tests/test_lua_api.py
+++ b/tests/test_lua_api.py
@@ -1,4 +1,5 @@
 from conftest import ScrollInstance
+from test_utils import wayland_client, wait_for_client_map
 
 
 def test_lua_comprehensive_api(scroll_compositor: ScrollInstance) -> None:
@@ -91,3 +92,54 @@ def test_lua_comprehensive_api(scroll_compositor: ScrollInstance) -> None:
     assert len(invalid_output_ws) == 0
 
     assert scroll_compositor.proc.poll() is None
+
+
+def test_lua_context_container(scroll_compositor: ScrollInstance) -> None:
+    # 1. Without criteria, context_container should return nil (None in Python)
+    ctx_con_glob: int | None = scroll_compositor.execute_lua(
+        "return scroll.context_container()"
+    )
+    assert ctx_con_glob is None
+
+    # 2. With criteria, context_container should return the matching container ID
+    with wayland_client(scroll_compositor, "client1"):
+        view_id = wait_for_client_map(scroll_compositor, "client1")
+        con_id = scroll_compositor.execute_lua(
+            f"return scroll.view_get_container({view_id})"
+        )
+        assert con_id is not None
+
+        # Execute lua command with criteria matching client1
+        scroll_compositor.cmd(
+            f'[con_id={con_id}] lua_eval test "_G.ctx_con_crit = scroll.context_container()"'
+        )
+        ctx_con_crit = scroll_compositor.execute_lua("return _G.ctx_con_crit")
+        assert ctx_con_crit == con_id
+
+        # 3. Nested calls with different contexts
+        with wayland_client(scroll_compositor, "client2"):
+            wait_for_client_map(scroll_compositor, "client2")
+            con2_id = scroll_compositor.execute_lua("return scroll.focused_container()")
+            assert con2_id is not None
+            assert con2_id != con_id
+
+            # Execute outer script with con_id criteria matching con_id
+            # Using lua_eval for both outer and nested calls!
+            scroll_compositor.cmd(
+                f'[con_id={con_id}] lua_eval outer "'
+                f"_G.nested_context = nil; "
+                f"_G.outer_context = scroll.context_container(); "
+                f"scroll.command({con2_id}, [[lua_eval inner '_G.nested_context = scroll.context_container()']]); "
+                f'_G.outer_context_post = scroll.context_container()"'
+            )
+
+            # Retrieve results
+            outer_context = scroll_compositor.execute_lua("return _G.outer_context")
+            nested_context = scroll_compositor.execute_lua("return _G.nested_context")
+            outer_context_post = scroll_compositor.execute_lua(
+                "return _G.outer_context_post"
+            )
+
+            assert outer_context == con_id
+            assert nested_context == con2_id
+            assert outer_context_post == con_id

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,84 +8,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from scrollipc import ScrollIPC
 
-RUNNER_LUA_CONTENT: str = """
-local args = ...
-local output_path = args[1]
-local user_code_path = args[2]
-
-local function escape_str(s)
-    return '"' .. s:gsub('\\\\', '\\\\\\\\'):gsub('"', '\\\\"'):gsub('\\n', '\\\\n'):gsub('\\r', '\\\\r'):gsub('\\t', '\\\\t') .. '"'
-end
-
-local function serialize(val)
-    if val == nil then return "null" end
-    if type(val) == "boolean" then return val and "true" or "false" end
-    if type(val) == "number" then return tostring(val) end
-    if type(val) == "string" then return escape_str(val) end
-    if type(val) == "table" then
-        local is_list = true
-        local max_idx = 0
-        local count = 0
-        for k, v in pairs(val) do
-            count = count + 1
-            if type(k) ~= "number" or k < 1 or math.floor(k) ~= k then
-                is_list = false
-                break
-            end
-            if k > max_idx then max_idx = k end
-        end
-        if is_list and max_idx == count then
-            local parts = {}
-            for i = 1, max_idx do
-                table.insert(parts, serialize(val[i]))
-            end
-            return "[" .. table.concat(parts, ",") .. "]"
-        else
-            local parts = {}
-            for k, v in pairs(val) do
-                if type(k) == "string" then
-                    table.insert(parts, escape_str(k) .. ":" .. serialize(v))
-                end
-            end
-            return "{" .. table.concat(parts, ",") .. "}"
-        end
-    end
-    return "null"
-end
-
-local chunk, err = loadfile(user_code_path)
-local success, result
-local results
-if chunk then
-    results = { pcall(chunk) }
-    success = results[1]
-else
-    success = false
-    results = { false, "Error loading code: " .. tostring(err) }
-end
-
-local f = io.open(output_path, "w")
-if success then
-    f:write("SUCCESS\\n")
-    if #results <= 1 then
-        f:write("null")
-    elseif #results == 2 then
-        f:write(serialize(results[2]))
-    else
-        local parts = {}
-        for i = 2, #results do
-            table.insert(parts, serialize(results[i]))
-        end
-        f:write("[" .. table.concat(parts, ",") .. "]")
-    end
-else
-    f:write("ERROR\\n")
-    f:write(tostring(results[2]))
-end
-f:close()
-"""
-
-DEFAULT_CONFIG = "workspace 1\nxwayland force\nanimations enabled no\n"
+DEFAULT_CONFIG: str = "workspace 1\nxwayland force\nanimations enabled no\n"
 
 class ScrollInstance:
     proc: subprocess.Popen
@@ -117,44 +40,15 @@ class ScrollInstance:
         self.wait_for_idle()
 
     def execute_lua(self, code: str) -> Any:
-        import json
-
-        runner_path = self.temp_dir / "exec_runner.lua"
-        if not runner_path.exists():
-            runner_path.write_text(RUNNER_LUA_CONTENT)
-
-        if not hasattr(self, "_lua_execute_counter"):
-            self._lua_execute_counter = 0
-        counter = self._lua_execute_counter
-        self._lua_execute_counter += 1
-
-        user_code_path = self.temp_dir / f"user_code_{counter}.lua"
-        output_path = self.temp_dir / f"exec_{counter}.out"
-
-        user_code_path.write_text(code)
-
-        res = self.cmd(f"lua {runner_path} {output_path} {user_code_path}")
-        assert res[0]["success"], f"Failed to run lua command: {res}"
-
-        assert output_path.exists(), (
-            f"Output file not created: {output_path}. Compositor log:\\n{self.read_log()}"
-        )
-        output_content = output_path.read_text()
-
-        lines = output_content.splitlines()
-        if not lines:
-            raise RuntimeError(
-                f"Lua runner output is empty. Compositor log:\\n{self.read_log()}"
-            )
-        status = lines[0]
-        result_str = "\\n".join(lines[1:])
-
-        if status == "SUCCESS":
-            if not result_str:
-                return None
-            return json.loads(result_str)
-        else:
-            raise RuntimeError(f"Lua execution failed: {result_str}")
+        res = self.ipc.lua_eval(code)
+        if not res.get("success"):
+            raise RuntimeError(f"Lua execution failed: {res.get('error')}")
+        results = res.get("results")
+        if results is None or len(results) == 0:
+            return None
+        if len(results) == 1:
+            return results[0]
+        return results
 
     def getenv(self, var: str) -> str | None:
         return self.execute_lua(f'return os.getenv("{var}")')


### PR DESCRIPTION
Exposes the criteria-matched container context to running Lua scripts via a new `scroll.context_container()` function.

If a script is run via criteria (e.g., `[class="XTerm"] lua_eval ...`), the function returns the matched container's ID. If executed globally without criteria, it returns `nil`.

To prevent nested executions of `scroll.command()` within a script from permanently overwriting the context, the active Lua context is backed up on entry to Lua command handlers (`lua` and `lua_eval`) and restored on exit.

Also documents the new API in `scroll.lua` and the `scroll.5` man page, and adds comprehensive pytest coverage.

This PR contains the one part of https://github.com/dawsers/scroll/pull/347 that you did not already implement.  The key feature that this enables is using Lua commands in `for_window` rules, and in particular `for_exec_window` rules (as implemented by #339).