### PR TITLE
Fix for floating windows on split-workspaces spawning on lower-sorted workspaces

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1345,7 +1345,12 @@ static struct sway_workspace *container_floating_find_workspace(struct sway_outp
 		double x_dist = closest_x - center_x;
 		double y_dist = closest_y - center_y;
 		double distance = x_dist * x_dist + y_dist * y_dist;
-		if (distance < closest_distance) {
+		// Prefer the current workspace on an exact center-distance tie,
+		// else the first equal-distance workspace in sorted order wins
+		// and the window jumps to an unrelated, lower-ordered workspace.
+		if (distance < closest_distance ||
+				(distance == closest_distance &&
+				 workspace == con->pending.workspace)) {
 			closest_workspace = workspace;
 			closest_distance = distance;
 		}


### PR DESCRIPTION
On a split workspace, a floating swayimg window would end up on the earliest-ordered workspace instead of staying on the current one (e.g. focused on 3, the window lands on 1).

The window first maps onto the correct (focused) workspace. The problem happens when swayimg's IPC `for_window [pid=…] move position` runs `container_floating_move_to()`. Because the current workspace is split, that path calls `container_floating_find_workspace()` to infer a workspace from the window's center. Split workspaces share identical geometry, so several are exactly equidistant, and the function's strict `<` comparison keeps the first candidate — in sorted order, the lowest-numbered workspace.

The patch made it such that on an exact center-distance tie, prefer the workspace the floating window already lives on (`con->pending.workspace`) instead of the earliest in sorted order. This should only affects the ambiguous tie case.